### PR TITLE
Remove refreshToken method from ClientCredentials

### DIFF
--- a/src/Client/ClientCredentials.php
+++ b/src/Client/ClientCredentials.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace DigitalCz\OpenIDConnect\Client;
 
 use DigitalCz\OpenIDConnect\Config\Config;
-use InvalidArgumentException;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 /**
@@ -39,33 +38,5 @@ final readonly class ClientCredentials
         $params['scope'] ??= implode(' ', $clientMetadata->defaultScopes());
 
         return $this->requestTokens($params);
-    }
-
-    /**
-     * Refresh access tokens using refresh token.
-     *
-     * @param Tokens $tokens Current tokens with refresh token
-     * @param array<string, string> $params Additional body parameters
-     * @return Tokens New tokens with fresh access token
-     */
-    public function refreshToken(Tokens $tokens, array $params = []): Tokens
-    {
-        if ($tokens->refreshToken() === null) {
-            throw new InvalidArgumentException('Cannot refresh tokens without a refresh token.');
-        }
-
-        $params['grant_type'] ??= 'refresh_token';
-        $params['refresh_token'] ??= (string)$tokens->refreshToken();
-
-        $newTokens = $this->requestTokens($params);
-
-        return new Tokens(
-            accessToken: $newTokens->accessToken(),
-            refreshToken: $newTokens->refreshToken() ?? $tokens->refreshToken(),
-            idToken: $newTokens->idToken() ?? $tokens->idToken(),
-            scope: $newTokens->scope(),
-            tokenType: $newTokens->tokenType(),
-            expiresIn: $newTokens->expiresIn(),
-        );
     }
 }


### PR DESCRIPTION
## Summary
- Remove the `refreshToken` method from `ClientCredentials` class as it does not make sense in the Client Credentials flow

## Rationale
The Client Credentials flow is designed for server-to-server authentication where refresh tokens are not typically used or needed. The presence of a refresh token method in this context was architecturally incorrect.

## Changes
- Removed `refreshToken()` method from `src/Client/ClientCredentials.php`
- Removed unused `InvalidArgumentException` import

## Test plan
- [x] All existing tests pass
- [x] Code style checks pass
- [x] Static analysis passes

🤖 Generated with [Claude Code](https://claude.ai/code)