### PR TITLE
fix: incorrect expected audience of access token

### DIFF
--- a/src/OidcFactory.php
+++ b/src/OidcFactory.php
@@ -109,7 +109,7 @@ final readonly class OidcFactory
         $jwtAccessTokenValidator = new JwtAccessTokenValidator(
             $config,
             $jwksLoader,
-            $clientMetadata->clientId(),
+            $config->issuerMetadata()->issuer(),
         );
 
         $resourceServer = new ResourceServer([


### PR DESCRIPTION
The access token validation is currently broken, because it incorrectly expected that the audience of the access token should be client id (which is true for id token), when in fact the correct expected value of audience of access token should be the issuer.