### PR TITLE
Add OpenID Connect Back-Channel Logout support

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ The `OidcFactory::create()` method accepts the following configuration options:
 | `tokenEndpointAuthSigningAlg` | `string\|null`                  | -        | `null`                           | Signature algorithm for client assertion JWT (e.g., `'HS256'`, `'RS256'`)                                  |
 | `clientAssertionAudience`     | `string\|null`                  | -        | `null`                           | Audience claim for client assertion JWT. Special values: `'{issuer}'`, `'{token_endpoint}'`, or custom URL |
 | `accessTokenType`             | `string\|null`                  | -        | `null`                           | Expected JWT access-token `typ` header (RFC 9068, e.g. `'at+jwt'`); `null` disables the check              |
+| `backchannelLogoutUri`        | `string\|null`                  | -        | `null`                           | RP endpoint the OP POSTs logout tokens to (informational; exposed via `clientMetadata()`)                  |
+| `backchannelLogoutSessionRequired` | `bool`                     | -        | `false`                          | Require the `sid` claim in logout tokens (rejected without it when `true`)                                 |
 
 #### Authentication Methods
 
@@ -189,6 +191,42 @@ $oidc = OidcFactory::create(
 
 When set, the `typ` header must be present and equal to the expected value; both `at+jwt` and `application/at+jwt`
 are accepted. It is disabled by default because not all authorization servers emit the `typ` header.
+
+### Back-Channel Logout
+
+Implements [OpenID Connect Back-Channel Logout 1.0](https://openid.net/specs/openid-connect-backchannel-1_0.html).
+The OP sends a server-to-server POST with a `logout_token` to your registered back-channel logout endpoint. Pass that
+token to the handler — it verifies the signature against the issuer JWKS and validates the logout-token claims
+(`iss`, `aud`, `iat`, `events`, no `nonce`, and `sub` and/or `sid`).
+
+```php
+use DigitalCz\OpenIDConnect\Exception\InvalidTokenException;
+
+$handler = $oidc->backChannelLogout();
+
+try {
+    // $_POST['logout_token'] is the form-encoded parameter sent by the OP
+    $logoutToken = $handler->handleLogoutRequest($_POST['logout_token']);
+} catch (InvalidTokenException $e) {
+    http_response_code(400);
+    return;
+}
+
+// Terminate the matching session(s). Use sid (this session) and/or sub (all of the user's sessions).
+$sid = $logoutToken->sid(); // ?string
+$sub = $logoutToken->sub(); // ?string
+
+http_response_code(200);
+```
+
+Two responsibilities the spec leaves to the application are intentionally left to you:
+
+- **Replay protection** — verify the `jti` (exposed via `$logoutToken->jti()`) has not been seen recently before
+  acting on the token.
+- **Session termination** — map `sid`/`sub` to your session store and destroy the relevant session(s).
+
+If the client is registered with `backchannelLogoutSessionRequired: true`, logout tokens without a `sid` claim are
+rejected.
 
 See [examples](examples) for more complete examples
 

--- a/examples/backchannel_logout.php
+++ b/examples/backchannel_logout.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+use DigitalCz\OpenIDConnect\Exception\InvalidTokenException;
+use DigitalCz\OpenIDConnect\OidcFactory;
+use Symfony\Component\HttpClient\HttpClient;
+
+require dirname(__DIR__) . '/vendor/autoload.php';
+
+$httpClient = HttpClient::create();
+
+$oidc = OidcFactory::create(
+    httpClient: $httpClient,
+    issuer: 'https://auth.example.com',
+    clientId: 'my-client-id',
+    clientSecret: 'my-client-secret',
+    // Reject logout tokens without a "sid" claim:
+    // backchannelLogoutSessionRequired: true,
+);
+
+$handler = $oidc->backChannelLogout();
+
+// In a real scenario this is the "logout_token" form parameter the OP POSTs
+// to your registered back-channel logout endpoint.
+$logoutToken = readline('Enter logout token: ');
+
+if ($logoutToken === false) {
+    throw new RuntimeException('Failed to read logout token');
+}
+
+try {
+    $token = $handler->handleLogoutRequest($logoutToken);
+} catch (InvalidTokenException $e) {
+    // Per spec, respond with HTTP 400 on an invalid logout token.
+    throw $e;
+}
+
+// The application is responsible for:
+//  - replay protection: ensure this jti has not been processed recently
+//  - session termination: destroy the session(s) for sid and/or sub
+dump(
+    jti: $token->jti(),
+    sub: $token->sub(),
+    sid: $token->sid(),
+);

--- a/examples/manual_config.php
+++ b/examples/manual_config.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+use DigitalCz\OpenIDConnect\BackChannelLogout\BackChannelLogoutHandler;
+use DigitalCz\OpenIDConnect\BackChannelLogout\JwtLogoutTokenValidator;
 use DigitalCz\OpenIDConnect\Client\AuthenticationMethod;
 use DigitalCz\OpenIDConnect\Client\AuthorizationCode;
 use DigitalCz\OpenIDConnect\Client\ClientCredentials;
@@ -70,7 +72,10 @@ $jwtAccessTokenValidator = new JwtAccessTokenValidator(
 // Optionally, you can also use an opaque access token validator
 $resourceServer = new ResourceServer([$jwtAccessTokenValidator]);
 
+// Create back-channel logout handler
+$backChannelLogout = new BackChannelLogoutHandler(new JwtLogoutTokenValidator($config, $jwksLoader));
+
 // Create OIDC instance manually
-$oidc = new Oidc($authorizationCode, $clientCredentials, $resourceServer);
+$oidc = new Oidc($authorizationCode, $clientCredentials, $resourceServer, $backChannelLogout);
 
 dump($oidc);

--- a/src/BackChannelLogout/BackChannelLogoutHandler.php
+++ b/src/BackChannelLogout/BackChannelLogoutHandler.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DigitalCz\OpenIDConnect\BackChannelLogout;
+
+use DigitalCz\OpenIDConnect\Exception\InvalidTokenException;
+use UnexpectedValueException;
+
+/**
+ * Entry point for processing OpenID Connect Back-Channel Logout requests.
+ *
+ * Applications should call {@see self::handleLogoutRequest()} with the
+ * `logout_token` POST parameter received on their back-channel logout
+ * endpoint. On success the returned {@see LogoutToken} exposes `sub` and/or
+ * `sid`, which the application uses to terminate the relevant sessions.
+ *
+ * @see https://openid.net/specs/openid-connect-backchannel-1_0.html
+ */
+final readonly class BackChannelLogoutHandler
+{
+    public function __construct(
+        private LogoutTokenValidator $validator,
+    ) {
+    }
+
+    /**
+     * Parses and validates a logout token string.
+     *
+     * @throws InvalidTokenException when the token is malformed or fails validation
+     */
+    public function handleLogoutRequest(string $logoutToken): LogoutToken
+    {
+        try {
+            $token = LogoutToken::from($logoutToken);
+        } catch (UnexpectedValueException $e) {
+            throw new InvalidTokenException('Invalid Logout Token: ' . $e->getMessage(), 0, $e);
+        }
+
+        $this->validator->validate($token);
+
+        return $token;
+    }
+}

--- a/src/BackChannelLogout/JwtLogoutTokenValidator.php
+++ b/src/BackChannelLogout/JwtLogoutTokenValidator.php
@@ -1,0 +1,157 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DigitalCz\OpenIDConnect\BackChannelLogout;
+
+use DigitalCz\OpenIDConnect\Config\Config;
+use DigitalCz\OpenIDConnect\Discovery\JwksLoader;
+use DigitalCz\OpenIDConnect\Exception\InvalidTokenException;
+use DigitalCz\OpenIDConnect\Util\SignatureAlgorithmsFactory;
+use DigitalCz\OpenIDConnect\Util\SimpleClock;
+use Exception;
+use Jose\Component\Checker\AlgorithmChecker;
+use Jose\Component\Checker\AudienceChecker;
+use Jose\Component\Checker\ClaimCheckerManager;
+use Jose\Component\Checker\ExpirationTimeChecker;
+use Jose\Component\Checker\HeaderCheckerManager;
+use Jose\Component\Checker\IssuedAtChecker;
+use Jose\Component\Checker\IssuerChecker;
+use Jose\Component\Checker\NotBeforeChecker;
+use Jose\Component\Core\AlgorithmManagerFactory;
+use Jose\Component\Core\JWKSet;
+use Jose\Component\Signature\JWSLoader;
+use Jose\Component\Signature\JWSTokenSupport;
+use Jose\Component\Signature\JWSVerifier;
+use Jose\Component\Signature\Serializer\CompactSerializer;
+use Jose\Component\Signature\Serializer\JWSSerializerManager;
+use Psr\Clock\ClockInterface;
+use Throwable;
+
+/**
+ * JWT-based Back-Channel Logout Token validator.
+ *
+ * Validates logout tokens per the OpenID Connect Back-Channel Logout 1.0 specification.
+ *
+ * @see https://openid.net/specs/openid-connect-backchannel-1_0.html#Validation
+ */
+final class JwtLogoutTokenValidator implements LogoutTokenValidator
+{
+    /**
+     * Required value of the logout event URI inside the `events` claim.
+     */
+    public const string LOGOUT_EVENT_URI = 'http://schemas.openid.net/event/backchannel-logout';
+
+    private ?ClaimCheckerManager $claimCheckerManager = null;
+    private ?JWSLoader $jwsLoader = null;
+
+    /**
+     * @param list<string> $mandatoryClaims
+     */
+    public function __construct(
+        private readonly Config $config,
+        private readonly JwksLoader $jwksLoader,
+        private readonly ClockInterface $clock = new SimpleClock(),
+        private readonly int $allowedTimeDrift = 10,
+        private readonly array $mandatoryClaims = ['iss', 'aud', 'iat', 'jti', 'events'],
+    ) {
+    }
+
+    /**
+     * Validates logout token signature, claims, and logout-specific requirements.
+     *
+     * @throws InvalidTokenException
+     */
+    public function validate(LogoutToken $token): void
+    {
+        try {
+            $this->validateSignature($token);
+            $this->validateClaims($token);
+            $this->validateLogoutTokenClaims($token);
+        } catch (Throwable $e) {
+            throw new InvalidTokenException('Invalid Logout Token: ' . $e->getMessage(), 0, $e);
+        }
+    }
+
+    /**
+     * Validates logout token signature using JWKS.
+     *
+     * @throws Exception
+     */
+    public function validateSignature(LogoutToken $token): void
+    {
+        $jwksUri = $this->config->issuerMetadata()->jwksUri();
+        $jwks = $this->jwksLoader->load($jwksUri);
+        $jwkSet = JWKSet::createFromKeyData($jwks);
+        $jwsLoader = $this->createJwsLoader();
+        $signature = null;
+        $jwsLoader->loadAndVerifyWithKeySet((string)$token, $jwkSet, $signature);
+    }
+
+    /**
+     * Enforces logout-token-specific rules:
+     *  - `events` claim is an object that includes the backchannel-logout event URI with an empty object value
+     *  - `nonce` claim MUST NOT be present
+     *  - At least one of `sub` or `sid` MUST be present
+     *
+     * @throws InvalidTokenException
+     */
+    public function validateLogoutTokenClaims(LogoutToken $token): void
+    {
+        if (!$token->has('events')) {
+            throw new InvalidTokenException('Logout Token MUST contain an "events" claim');
+        }
+
+        $events = $token->events();
+
+        if (!array_key_exists(self::LOGOUT_EVENT_URI, $events)) {
+            throw new InvalidTokenException(
+                sprintf('"events" claim must contain the "%s" member', self::LOGOUT_EVENT_URI),
+            );
+        }
+
+        $logoutEvent = $events[self::LOGOUT_EVENT_URI];
+
+        if (!is_array($logoutEvent)) {
+            throw new InvalidTokenException(
+                sprintf('"events" member "%s" must be an object', self::LOGOUT_EVENT_URI),
+            );
+        }
+
+        if ($token->has('nonce')) {
+            throw new InvalidTokenException('Logout Token MUST NOT contain a "nonce" claim');
+        }
+
+        if (!$token->has('sub') && !$token->has('sid')) {
+            throw new InvalidTokenException('Logout Token MUST contain either a "sub" or "sid" claim');
+        }
+    }
+
+    private function createJwsLoader(): JWSLoader
+    {
+        $signingAlgorithms = $this->config->issuerMetadata()->idTokenSigningAlgValuesSupported();
+        $algorithmManagerFactory = new AlgorithmManagerFactory(SignatureAlgorithmsFactory::create());
+
+        return $this->jwsLoader ??= new JWSLoader(
+            new JWSSerializerManager([new CompactSerializer()]),
+            new JWSVerifier($algorithmManagerFactory->create($signingAlgorithms)),
+            new HeaderCheckerManager([new AlgorithmChecker($signingAlgorithms)], [new JWSTokenSupport()]),
+        );
+    }
+
+    private function validateClaims(LogoutToken $token): void
+    {
+        $this->createClaimCheckerManager()->check($token->claims(), $this->mandatoryClaims);
+    }
+
+    private function createClaimCheckerManager(): ClaimCheckerManager
+    {
+        return $this->claimCheckerManager ??= new ClaimCheckerManager([
+            new IssuerChecker([$this->config->issuerMetadata()->issuer()]),
+            new AudienceChecker($this->config->clientMetadata()->clientId()),
+            new ExpirationTimeChecker($this->clock, $this->allowedTimeDrift),
+            new IssuedAtChecker($this->clock, $this->allowedTimeDrift),
+            new NotBeforeChecker($this->clock, $this->allowedTimeDrift),
+        ]);
+    }
+}

--- a/src/BackChannelLogout/JwtLogoutTokenValidator.php
+++ b/src/BackChannelLogout/JwtLogoutTokenValidator.php
@@ -93,6 +93,7 @@ final class JwtLogoutTokenValidator implements LogoutTokenValidator
      *  - `events` claim is an object that includes the backchannel-logout event URI with an empty object value
      *  - `nonce` claim MUST NOT be present
      *  - At least one of `sub` or `sid` MUST be present
+     *  - `sid` MUST be present when the client registered `backchannel_logout_session_required`
      *
      * @throws InvalidTokenException
      */
@@ -124,6 +125,12 @@ final class JwtLogoutTokenValidator implements LogoutTokenValidator
 
         if (!$token->has('sub') && !$token->has('sid')) {
             throw new InvalidTokenException('Logout Token MUST contain either a "sub" or "sid" claim');
+        }
+
+        if ($this->config->clientMetadata()->backchannelLogoutSessionRequired() && !$token->has('sid')) {
+            throw new InvalidTokenException(
+                'Logout Token MUST contain a "sid" claim because back-channel logout session is required',
+            );
         }
     }
 

--- a/src/BackChannelLogout/LogoutToken.php
+++ b/src/BackChannelLogout/LogoutToken.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DigitalCz\OpenIDConnect\BackChannelLogout;
+
+use DigitalCz\OpenIDConnect\Util\ClaimsTrait;
+use DigitalCz\OpenIDConnect\Util\JWT;
+use Stringable;
+use UnexpectedValueException;
+
+/**
+ * OpenID Connect Back-Channel Logout Token.
+ *
+ * @see https://openid.net/specs/openid-connect-backchannel-1_0.html
+ */
+final readonly class LogoutToken
+{
+    use ClaimsTrait;
+
+    /**
+     * @param string $token The raw JWT logout token string
+     */
+    public function __construct(
+        private string $token,
+    ) {
+    }
+
+    /**
+     * Creates a LogoutToken instance from various input types.
+     *
+     * @param mixed $value The value to create LogoutToken from. Can be:
+     *                     - string: JWT token string
+     *                     - array: Must contain 'logout_token' key with JWT string value
+     *                     - Stringable: Will be converted to string
+     *
+     * @throws UnexpectedValueException If the value cannot be converted to a valid JWT logout token
+     */
+    public static function from(mixed $value): self
+    {
+        if (is_array($value)) {
+            if (!isset($value['logout_token'])) {
+                throw new UnexpectedValueException('Cannot create LogoutToken from array without "logout_token" key');
+            }
+
+            $value = $value['logout_token'];
+        }
+
+        if ($value instanceof Stringable) {
+            $value = (string) $value;
+        }
+
+        if (!is_string($value)) {
+            throw new UnexpectedValueException('Cannot create LogoutToken from ' . get_debug_type($value));
+        }
+
+        if (!JWT::validate($value)) {
+            throw new UnexpectedValueException('Invalid JWT logout token format');
+        }
+
+        return new self($value);
+    }
+
+    public static function tryFrom(mixed $value): ?self
+    {
+        try {
+            return self::from($value);
+        } catch (UnexpectedValueException) {
+            return null;
+        }
+    }
+
+    public function iss(): string
+    {
+        return $this->string('iss');
+    }
+
+    /**
+     * Get the audience claim.
+     *
+     * Logout tokens MAY contain either a single string or an array of strings.
+     *
+     * @return string|list<string>
+     */
+    public function aud(): string|array
+    {
+        $value = $this->get('aud');
+
+        if (is_string($value)) {
+            return $value;
+        }
+
+        return array_values($this->strings('aud'));
+    }
+
+    public function iat(): int
+    {
+        return $this->integer('iat');
+    }
+
+    public function jti(): string
+    {
+        return $this->string('jti');
+    }
+
+    /**
+     * Subject identifier. Either `sub` or `sid` MUST be present; both MAY be.
+     */
+    public function sub(): ?string
+    {
+        return $this->has('sub') ? $this->string('sub') : null;
+    }
+
+    /**
+     * Session identifier. Either `sub` or `sid` MUST be present; both MAY be.
+     */
+    public function sid(): ?string
+    {
+        return $this->has('sid') ? $this->string('sid') : null;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function events(): array
+    {
+        $value = $this->get('events');
+
+        if (!is_array($value)) {
+            throw new UnexpectedValueException('Claim "events" is required and must be an object.');
+        }
+
+        /** @var array<string, mixed> $value */
+        return $value;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function claims(): array
+    {
+        return JWT::claims($this->token);
+    }
+
+    public function __toString(): string
+    {
+        return $this->token;
+    }
+}

--- a/src/BackChannelLogout/LogoutTokenValidator.php
+++ b/src/BackChannelLogout/LogoutTokenValidator.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DigitalCz\OpenIDConnect\BackChannelLogout;
+
+use DigitalCz\OpenIDConnect\Exception\InvalidTokenException;
+
+/**
+ * Interface for Back-Channel Logout Token validation implementations.
+ *
+ * @see https://openid.net/specs/openid-connect-backchannel-1_0.html#Validation
+ */
+interface LogoutTokenValidator
+{
+    /**
+     * @throws InvalidTokenException
+     */
+    public function validate(LogoutToken $token): void;
+}

--- a/src/Config/ClientMetadata.php
+++ b/src/Config/ClientMetadata.php
@@ -32,6 +32,8 @@ final readonly class ClientMetadata
         private ?string $tokenEndpointAuthSigningAlg = null,
         private ?string $clientAssertionAudience = null,
         private ?ClockInterface $clock = null,
+        private ?string $backchannelLogoutUri = null,
+        private bool $backchannelLogoutSessionRequired = false,
     ) {
     }
 
@@ -91,6 +93,23 @@ final readonly class ClientMetadata
     public function clock(): ClockInterface
     {
         return $this->clock ?? new SimpleClock();
+    }
+
+    /**
+     * The URI the OP will POST logout tokens to, or null if back-channel logout
+     * is not configured for this client.
+     */
+    public function backchannelLogoutUri(): ?string
+    {
+        return $this->backchannelLogoutUri;
+    }
+
+    /**
+     * Whether this client requires a `sid` (Session ID) claim in logout tokens.
+     */
+    public function backchannelLogoutSessionRequired(): bool
+    {
+        return $this->backchannelLogoutSessionRequired;
     }
 
     /**

--- a/src/Config/IssuerMetadata.php
+++ b/src/Config/IssuerMetadata.php
@@ -88,6 +88,25 @@ final readonly class IssuerMetadata
     }
 
     /**
+     * Whether the provider supports Back-Channel Logout.
+     *
+     * @see https://openid.net/specs/openid-connect-backchannel-1_0.html#BCSupport
+     */
+    public function backchannelLogoutSupported(): bool
+    {
+        return $this->has('backchannel_logout_supported') && $this->boolean('backchannel_logout_supported');
+    }
+
+    /**
+     * Whether the provider can convey a `sid` (Session ID) claim in logout tokens.
+     */
+    public function backchannelLogoutSessionSupported(): bool
+    {
+        return $this->has('backchannel_logout_session_supported')
+            && $this->boolean('backchannel_logout_session_supported');
+    }
+
+    /**
      * @return array<string>
      */
     public function scopesSupported(): array

--- a/src/Oidc.php
+++ b/src/Oidc.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace DigitalCz\OpenIDConnect;
 
+use DigitalCz\OpenIDConnect\BackChannelLogout\BackChannelLogoutHandler;
 use DigitalCz\OpenIDConnect\Client\AuthorizationCode;
 use DigitalCz\OpenIDConnect\Client\ClientCredentials;
 use DigitalCz\OpenIDConnect\ResourceServer\ResourceServer;
@@ -17,6 +18,7 @@ final readonly class Oidc
         private AuthorizationCode $authorizationCode,
         private ClientCredentials $clientCredentials,
         private ResourceServer $resourceServer,
+        private BackChannelLogoutHandler $backChannelLogout,
     ) {
     }
 
@@ -33,5 +35,10 @@ final readonly class Oidc
     public function resourceServer(): ResourceServer
     {
         return $this->resourceServer;
+    }
+
+    public function backChannelLogout(): BackChannelLogoutHandler
+    {
+        return $this->backChannelLogout;
     }
 }

--- a/src/OidcFactory.php
+++ b/src/OidcFactory.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace DigitalCz\OpenIDConnect;
 
+use DigitalCz\OpenIDConnect\BackChannelLogout\BackChannelLogoutHandler;
+use DigitalCz\OpenIDConnect\BackChannelLogout\JwtLogoutTokenValidator;
 use DigitalCz\OpenIDConnect\Client\AuthenticationMethod;
 use DigitalCz\OpenIDConnect\Client\AuthorizationCode;
 use DigitalCz\OpenIDConnect\Client\ClientCredentials;
@@ -54,6 +56,8 @@ final readonly class OidcFactory
         ?string $tokenEndpointAuthSigningAlg = null,
         ?string $clientAssertionAudience = null,
         ?string $accessTokenType = null,
+        ?string $backchannelLogoutUri = null,
+        bool $backchannelLogoutSessionRequired = false,
     ): Oidc {
         if (is_string($defaultScopes)) {
             $defaultScopes = explode(' ', $defaultScopes);
@@ -82,6 +86,8 @@ final readonly class OidcFactory
             tokenEndpointAuthSigningAlg: $tokenEndpointAuthSigningAlg,
             clientAssertionAudience: $clientAssertionAudience,
             clock: $clock,
+            backchannelLogoutUri: $backchannelLogoutUri,
+            backchannelLogoutSessionRequired: $backchannelLogoutSessionRequired,
         );
 
         if (is_string($issuer)) {
@@ -134,6 +140,10 @@ final readonly class OidcFactory
             $opaqueAccessTokenValidator,
         ]);
 
-        return new Oidc($authorizationCode, $clientCredentials, $resourceServer);
+        $backChannelLogoutHandler = new BackChannelLogoutHandler(
+            new JwtLogoutTokenValidator($config, $jwksLoader, $clock),
+        );
+
+        return new Oidc($authorizationCode, $clientCredentials, $resourceServer, $backChannelLogoutHandler);
     }
 }

--- a/tests/BackChannelLogout/BackChannelLogoutHandlerTest.php
+++ b/tests/BackChannelLogout/BackChannelLogoutHandlerTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DigitalCz\OpenIDConnect\BackChannelLogout;
+
+use DigitalCz\OpenIDConnect\Exception\InvalidTokenException;
+use DigitalCz\OpenIDConnect\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\MockObject\MockObject;
+
+#[CoversClass(BackChannelLogoutHandler::class)]
+class BackChannelLogoutHandlerTest extends TestCase
+{
+    private LogoutTokenValidator&MockObject $validator;
+
+    public function testHandleLogoutRequestReturnsParsedToken(): void
+    {
+        $jwt = $this->createLogoutJwt();
+        $handler = new BackChannelLogoutHandler($this->validator);
+
+        $this->validator
+            ->expects($this->once())
+            ->method('validate')
+            ->with($this->callback(static fn (LogoutToken $t): bool => (string) $t === $jwt));
+
+        $token = $handler->handleLogoutRequest($jwt);
+
+        $this->assertInstanceOf(LogoutToken::class, $token);
+        $this->assertSame($jwt, (string) $token);
+    }
+
+    public function testHandleLogoutRequestWithMalformedJwtThrows(): void
+    {
+        $handler = new BackChannelLogoutHandler($this->validator);
+
+        $this->validator->expects($this->never())->method('validate');
+
+        $this->expectException(InvalidTokenException::class);
+        $this->expectExceptionMessage('Invalid Logout Token');
+        $handler->handleLogoutRequest('not-a-jwt');
+    }
+
+    public function testHandleLogoutRequestPropagatesValidatorFailure(): void
+    {
+        $handler = new BackChannelLogoutHandler($this->validator);
+
+        $this->validator
+            ->method('validate')
+            ->willThrowException(new InvalidTokenException('Invalid Logout Token: boom'));
+
+        $this->expectException(InvalidTokenException::class);
+        $this->expectExceptionMessage('boom');
+        $handler->handleLogoutRequest($this->createLogoutJwt());
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->validator = $this->createMock(LogoutTokenValidator::class);
+    }
+
+    private function createLogoutJwt(): string
+    {
+        return $this->createCustomJwt(
+            ['typ' => 'logout+jwt', 'alg' => 'RS256', 'kid' => 'test-key-id'],
+            [
+                'iss' => 'https://auth.example.com',
+                'aud' => 'test-client-id',
+                'iat' => time(),
+                'jti' => 'jti-test',
+                'sub' => 'user-1',
+                'events' => [JwtLogoutTokenValidator::LOGOUT_EVENT_URI => []],
+            ],
+        );
+    }
+}

--- a/tests/BackChannelLogout/JwtLogoutTokenValidatorTest.php
+++ b/tests/BackChannelLogout/JwtLogoutTokenValidatorTest.php
@@ -1,0 +1,385 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DigitalCz\OpenIDConnect\BackChannelLogout;
+
+use DateTimeImmutable;
+use DigitalCz\OpenIDConnect\Client\AuthenticationMethod;
+use DigitalCz\OpenIDConnect\Config\ClientMetadata;
+use DigitalCz\OpenIDConnect\Config\Config;
+use DigitalCz\OpenIDConnect\Config\IssuerMetadata;
+use DigitalCz\OpenIDConnect\Discovery\JwksLoader;
+use DigitalCz\OpenIDConnect\Exception\InvalidTokenException;
+use DigitalCz\OpenIDConnect\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Clock\ClockInterface;
+use RuntimeException;
+
+#[CoversClass(JwtLogoutTokenValidator::class)]
+class JwtLogoutTokenValidatorTest extends TestCase
+{
+    private Config&MockObject $config;
+    private JwksLoader&MockObject $jwksLoader;
+    private IssuerMetadata $issuerMetadata;
+    private ClientMetadata $clientMetadata;
+    private ClockInterface&MockObject $clock;
+
+    public function testConstructor(): void
+    {
+        $validator = new JwtLogoutTokenValidator(
+            $this->config,
+            $this->jwksLoader,
+            $this->clock,
+            15,
+            ['iss', 'aud', 'iat', 'jti', 'events', 'custom'],
+        );
+
+        $this->assertInstanceOf(JwtLogoutTokenValidator::class, $validator);
+        $this->assertInstanceOf(LogoutTokenValidator::class, $validator);
+    }
+
+    public function testConstructorWithDefaults(): void
+    {
+        $validator = new JwtLogoutTokenValidator($this->config, $this->jwksLoader);
+
+        $this->assertInstanceOf(JwtLogoutTokenValidator::class, $validator);
+        $this->assertInstanceOf(LogoutTokenValidator::class, $validator);
+    }
+
+    /**
+     * @param list<string> $mandatoryClaims
+     */
+    #[DataProvider('mandatoryClaimsProvider')]
+    public function testConstructorWithCustomMandatoryClaims(array $mandatoryClaims): void
+    {
+        $validator = new JwtLogoutTokenValidator($this->config, $this->jwksLoader, $this->clock, 10, $mandatoryClaims);
+
+        $this->assertInstanceOf(JwtLogoutTokenValidator::class, $validator);
+    }
+
+    /**
+     * @return array<string, array{list<string>}>
+     */
+    public static function mandatoryClaimsProvider(): array
+    {
+        return [
+            'minimal claims' => [['iss', 'aud']],
+            'standard claims' => [['iss', 'aud', 'iat', 'jti', 'events']],
+            'extended claims' => [['iss', 'aud', 'iat', 'jti', 'events', 'sub']],
+            'empty claims' => [[]],
+        ];
+    }
+
+    public function testValidateWithInvalidSignature(): void
+    {
+        $validator = new JwtLogoutTokenValidator($this->config, $this->jwksLoader, $this->clock);
+        $token = $this->createValidLogoutToken();
+
+        $this->setupSuccessfulJwksLoad();
+
+        $this->expectException(InvalidTokenException::class);
+        $this->expectExceptionMessage('Invalid Logout Token');
+        $validator->validate($token);
+    }
+
+    public function testValidateWithJwksLoadFailure(): void
+    {
+        $validator = new JwtLogoutTokenValidator($this->config, $this->jwksLoader, $this->clock);
+        $token = $this->createValidLogoutToken();
+
+        $this->jwksLoader->method('load')
+            ->willThrowException(new RuntimeException('JWKS load failed'));
+
+        $this->expectException(InvalidTokenException::class);
+        $this->expectExceptionMessage('Invalid Logout Token: JWKS load failed');
+        $validator->validate($token);
+    }
+
+    public function testValidateSignatureCallsJwksLoader(): void
+    {
+        $validator = new JwtLogoutTokenValidator($this->config, $this->jwksLoader, $this->clock);
+        $token = $this->createValidLogoutToken();
+
+        $this->jwksLoader->expects($this->once())
+            ->method('load')
+            ->with('https://auth.example.com/.well-known/jwks.json')
+            ->willReturn($this->createSampleJwks());
+
+        $this->expectException(InvalidTokenException::class);
+        $validator->validate($token);
+    }
+
+    public function testValidateWithWrongIssuer(): void
+    {
+        $validator = new JwtLogoutTokenValidator($this->config, $this->jwksLoader, $this->clock);
+        $token = $this->createLogoutTokenWithPayload(['iss' => 'https://wrong-issuer.example.com']);
+
+        $this->setupSuccessfulJwksLoad();
+
+        $this->expectException(InvalidTokenException::class);
+        $validator->validate($token);
+    }
+
+    public function testValidateWithWrongAudience(): void
+    {
+        $validator = new JwtLogoutTokenValidator($this->config, $this->jwksLoader, $this->clock);
+        $token = $this->createLogoutTokenWithPayload(['aud' => 'wrong-client-id']);
+
+        $this->setupSuccessfulJwksLoad();
+
+        $this->expectException(InvalidTokenException::class);
+        $validator->validate($token);
+    }
+
+    public function testValidateWithMissingEventsClaim(): void
+    {
+        $validator = new JwtLogoutTokenValidator($this->config, $this->jwksLoader, $this->clock);
+        $token = $this->createLogoutTokenWithoutClaims(['events']);
+
+        $this->setupSuccessfulJwksLoad();
+
+        $this->expectException(InvalidTokenException::class);
+        $validator->validate($token);
+    }
+
+    public function testValidateLogoutTokenClaimsAcceptsValidToken(): void
+    {
+        $validator = new JwtLogoutTokenValidator($this->config, $this->jwksLoader, $this->clock);
+        $token = $this->createValidLogoutToken();
+
+        // Should not throw on a well-formed logout-token payload
+        $validator->validateLogoutTokenClaims($token);
+        $this->addToAssertionCount(1);
+    }
+
+    public function testValidateLogoutTokenClaimsAcceptsSidOnly(): void
+    {
+        $validator = new JwtLogoutTokenValidator($this->config, $this->jwksLoader, $this->clock);
+        $payload = $this->baseLogoutPayload();
+        unset($payload['sub']);
+        $payload['sid'] = 'session-id-only';
+        $token = new LogoutToken($this->createCustomJwt($this->logoutJwtHeader(), $payload));
+
+        $validator->validateLogoutTokenClaims($token);
+        $this->addToAssertionCount(1);
+    }
+
+    public function testValidateLogoutTokenClaimsWithMissingEventsThrows(): void
+    {
+        $validator = new JwtLogoutTokenValidator($this->config, $this->jwksLoader, $this->clock);
+        $token = $this->createLogoutTokenWithoutClaims(['events']);
+
+        $this->expectException(InvalidTokenException::class);
+        $validator->validateLogoutTokenClaims($token);
+    }
+
+    public function testValidateLogoutTokenClaimsWithEventsMissingLogoutEventKey(): void
+    {
+        $validator = new JwtLogoutTokenValidator($this->config, $this->jwksLoader, $this->clock);
+        $token = $this->createLogoutTokenWithPayload([
+            'events' => ['http://example.com/other-event' => []],
+        ]);
+
+        $this->expectException(InvalidTokenException::class);
+        $this->expectExceptionMessage('must contain');
+        $validator->validateLogoutTokenClaims($token);
+    }
+
+    public function testValidateLogoutTokenClaimsWithLogoutEventValueNotAnObject(): void
+    {
+        $validator = new JwtLogoutTokenValidator($this->config, $this->jwksLoader, $this->clock);
+        $token = $this->createLogoutTokenWithPayload([
+            'events' => [JwtLogoutTokenValidator::LOGOUT_EVENT_URI => 'not-an-object'],
+        ]);
+
+        $this->expectException(InvalidTokenException::class);
+        $this->expectExceptionMessage('must be an object');
+        $validator->validateLogoutTokenClaims($token);
+    }
+
+    public function testValidateLogoutTokenClaimsRejectsNonce(): void
+    {
+        $validator = new JwtLogoutTokenValidator($this->config, $this->jwksLoader, $this->clock);
+        $token = $this->createLogoutTokenWithPayload(['nonce' => 'should-not-be-here']);
+
+        $this->expectException(InvalidTokenException::class);
+        $this->expectExceptionMessage('MUST NOT contain a "nonce" claim');
+        $validator->validateLogoutTokenClaims($token);
+    }
+
+    public function testValidateLogoutTokenClaimsRejectsMissingSubAndSid(): void
+    {
+        $validator = new JwtLogoutTokenValidator($this->config, $this->jwksLoader, $this->clock);
+        $token = $this->createLogoutTokenWithoutClaims(['sub', 'sid']);
+
+        $this->expectException(InvalidTokenException::class);
+        $this->expectExceptionMessage('MUST contain either a "sub" or "sid" claim');
+        $validator->validateLogoutTokenClaims($token);
+    }
+
+    public function testValidateWithSidOnly(): void
+    {
+        // Token has sid, no sub. Should reach signature check (fail there with our fake JWKS).
+        $validator = new JwtLogoutTokenValidator($this->config, $this->jwksLoader, $this->clock);
+        $payload = $this->baseLogoutPayload();
+        unset($payload['sub']);
+        $payload['sid'] = 'session-id-only';
+        $token = new LogoutToken($this->createCustomJwt($this->logoutJwtHeader(), $payload));
+
+        $this->setupSuccessfulJwksLoad();
+
+        // Signature check will fail (our test JWKS is synthetic), but that proves
+        // the validator proceeded past the sid-only presence requirement.
+        $this->expectException(InvalidTokenException::class);
+        $validator->validate($token);
+    }
+
+    public function testValidateWithMissingRequiredClaims(): void
+    {
+        $validator = new JwtLogoutTokenValidator($this->config, $this->jwksLoader, $this->clock);
+        $token = $this->createLogoutTokenWithoutClaims(['jti']);
+
+        $this->setupSuccessfulJwksLoad();
+
+        $this->expectException(InvalidTokenException::class);
+        $validator->validate($token);
+    }
+
+    public function testValidateWithFutureIat(): void
+    {
+        $validator = new JwtLogoutTokenValidator($this->config, $this->jwksLoader, $this->clock);
+        $token = $this->createLogoutTokenWithPayload(['iat' => time() + 3600]);
+
+        $this->setupSuccessfulJwksLoad();
+
+        $this->expectException(InvalidTokenException::class);
+        $validator->validate($token);
+    }
+
+    public function testValidateSignatureWithInvalidJwks(): void
+    {
+        $validator = new JwtLogoutTokenValidator($this->config, $this->jwksLoader, $this->clock);
+        $token = $this->createValidLogoutToken();
+
+        $this->jwksLoader->method('load')->willReturn([]);
+
+        $this->expectException(InvalidTokenException::class);
+        $validator->validate($token);
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->config = $this->createMock(Config::class);
+        $this->jwksLoader = $this->createMock(JwksLoader::class);
+        $this->issuerMetadata = $this->createRealIssuerMetadata();
+        $this->clientMetadata = $this->createRealClientMetadata();
+        $this->clock = $this->createMock(ClockInterface::class);
+
+        $this->setupDefaultMocks();
+    }
+
+    private function setupDefaultMocks(): void
+    {
+        $this->config->method('issuerMetadata')->willReturn($this->issuerMetadata);
+        $this->config->method('clientMetadata')->willReturn($this->clientMetadata);
+        $this->clock->method('now')->willReturn(new DateTimeImmutable('@' . time()));
+    }
+
+    private function createRealIssuerMetadata(): IssuerMetadata
+    {
+        return new IssuerMetadata([
+            'issuer' => 'https://auth.example.com',
+            'authorization_endpoint' => 'https://auth.example.com/oauth/authorize',
+            'token_endpoint' => 'https://auth.example.com/oauth/token',
+            'jwks_uri' => 'https://auth.example.com/.well-known/jwks.json',
+            'userinfo_endpoint' => 'https://auth.example.com/userinfo',
+            'response_types_supported' => ['code', 'token', 'id_token'],
+            'subject_types_supported' => ['public', 'pairwise'],
+            'id_token_signing_alg_values_supported' => ['RS256', 'ES256'],
+            'backchannel_logout_supported' => true,
+            'backchannel_logout_session_supported' => true,
+        ]);
+    }
+
+    private function createRealClientMetadata(): ClientMetadata
+    {
+        return new ClientMetadata(
+            clientId: 'test-client-id',
+            clientSecret: 'test-client-secret',
+            redirectUri: 'https://client.example.com/callback',
+            defaultScopes: ['openid', 'profile', 'email'],
+            authenticationMethod: AuthenticationMethod::ClientSecretPost,
+            backchannelLogoutUri: 'https://client.example.com/logout/backchannel',
+            backchannelLogoutSessionRequired: true,
+        );
+    }
+
+    private function createValidLogoutToken(): LogoutToken
+    {
+        return new LogoutToken(
+            $this->createCustomJwt($this->logoutJwtHeader(), $this->baseLogoutPayload()),
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $overrides
+     */
+    private function createLogoutTokenWithPayload(array $overrides): LogoutToken
+    {
+        return new LogoutToken(
+            $this->createCustomJwt(
+                $this->logoutJwtHeader(),
+                array_merge($this->baseLogoutPayload(), $overrides),
+            ),
+        );
+    }
+
+    /**
+     * @param list<string> $removed
+     */
+    private function createLogoutTokenWithoutClaims(array $removed): LogoutToken
+    {
+        $payload = $this->baseLogoutPayload();
+
+        foreach ($removed as $claim) {
+            unset($payload[$claim]);
+        }
+
+        return new LogoutToken($this->createCustomJwt($this->logoutJwtHeader(), $payload));
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function logoutJwtHeader(): array
+    {
+        return ['typ' => 'logout+jwt', 'alg' => 'RS256', 'kid' => 'test-key-id'];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function baseLogoutPayload(): array
+    {
+        return [
+            'iss' => 'https://auth.example.com',
+            'aud' => 'test-client-id',
+            'iat' => time(),
+            'jti' => 'unique-jti-id',
+            'sub' => 'user-42',
+            'events' => [
+                JwtLogoutTokenValidator::LOGOUT_EVENT_URI => [],
+            ],
+        ];
+    }
+
+    private function setupSuccessfulJwksLoad(): void
+    {
+        $this->jwksLoader->method('load')->willReturn($this->createSampleJwks());
+    }
+}

--- a/tests/BackChannelLogout/JwtLogoutTokenValidatorTest.php
+++ b/tests/BackChannelLogout/JwtLogoutTokenValidatorTest.php
@@ -220,6 +220,38 @@ class JwtLogoutTokenValidatorTest extends TestCase
         $validator->validateLogoutTokenClaims($token);
     }
 
+    public function testValidateLogoutTokenClaimsRequiresSidWhenSessionRequired(): void
+    {
+        $config = $this->configWithSessionRequired(true);
+        $validator = new JwtLogoutTokenValidator($config, $this->jwksLoader, $this->clock);
+        // base payload carries `sub` but no `sid`
+        $token = $this->createValidLogoutToken();
+
+        $this->expectException(InvalidTokenException::class);
+        $this->expectExceptionMessage('because back-channel logout session is required');
+        $validator->validateLogoutTokenClaims($token);
+    }
+
+    public function testValidateLogoutTokenClaimsAcceptsSidWhenSessionRequired(): void
+    {
+        $config = $this->configWithSessionRequired(true);
+        $validator = new JwtLogoutTokenValidator($config, $this->jwksLoader, $this->clock);
+        $token = $this->createLogoutTokenWithPayload(['sid' => 'session-123']);
+
+        $validator->validateLogoutTokenClaims($token);
+        $this->addToAssertionCount(1);
+    }
+
+    public function testValidateLogoutTokenClaimsAllowsMissingSidWhenSessionNotRequired(): void
+    {
+        // Default config has session not required; `sub` alone is sufficient.
+        $validator = new JwtLogoutTokenValidator($this->config, $this->jwksLoader, $this->clock);
+        $token = $this->createLogoutTokenWithoutClaims(['sid']);
+
+        $validator->validateLogoutTokenClaims($token);
+        $this->addToAssertionCount(1);
+    }
+
     public function testValidateWithSidOnly(): void
     {
         // Token has sid, no sub. Should reach signature check (fail there with our fake JWKS).
@@ -315,8 +347,27 @@ class JwtLogoutTokenValidatorTest extends TestCase
             defaultScopes: ['openid', 'profile', 'email'],
             authenticationMethod: AuthenticationMethod::ClientSecretPost,
             backchannelLogoutUri: 'https://client.example.com/logout/backchannel',
-            backchannelLogoutSessionRequired: true,
+            backchannelLogoutSessionRequired: false,
         );
+    }
+
+    private function configWithSessionRequired(bool $required): Config&MockObject
+    {
+        $clientMetadata = new ClientMetadata(
+            clientId: 'test-client-id',
+            clientSecret: 'test-client-secret',
+            redirectUri: 'https://client.example.com/callback',
+            defaultScopes: ['openid', 'profile', 'email'],
+            authenticationMethod: AuthenticationMethod::ClientSecretPost,
+            backchannelLogoutUri: 'https://client.example.com/logout/backchannel',
+            backchannelLogoutSessionRequired: $required,
+        );
+
+        $config = $this->createMock(Config::class);
+        $config->method('issuerMetadata')->willReturn($this->issuerMetadata);
+        $config->method('clientMetadata')->willReturn($clientMetadata);
+
+        return $config;
     }
 
     private function createValidLogoutToken(): LogoutToken

--- a/tests/BackChannelLogout/JwtLogoutTokenValidatorTest.php
+++ b/tests/BackChannelLogout/JwtLogoutTokenValidatorTest.php
@@ -73,6 +73,45 @@ class JwtLogoutTokenValidatorTest extends TestCase
         ];
     }
 
+    public function testValidateAcceptsProperlySignedLogoutToken(): void
+    {
+        $validator = new JwtLogoutTokenValidator($this->config, $this->jwksLoader, $this->clock);
+        $token = new LogoutToken($this->createSignedJwt([
+            'iss' => 'https://auth.example.com',
+            'aud' => 'test-client-id',
+            'iat' => time(),
+            'jti' => 'unique-jti-id',
+            'sub' => 'user-42',
+            'events' => [JwtLogoutTokenValidator::LOGOUT_EVENT_URI => []],
+        ]));
+
+        $this->jwksLoader->method('load')->willReturn($this->publicJwks());
+
+        // Full happy path: signature verifies, standard claims and logout-specific rules pass.
+        $validator->validate($token);
+        $this->addToAssertionCount(1);
+    }
+
+    public function testValidateRejectsSignedTokenWithExpiredExp(): void
+    {
+        $validator = new JwtLogoutTokenValidator($this->config, $this->jwksLoader, $this->clock);
+        $token = new LogoutToken($this->createSignedJwt([
+            'iss' => 'https://auth.example.com',
+            'aud' => 'test-client-id',
+            'iat' => time() - 7200,
+            'exp' => time() - 3600,
+            'jti' => 'unique-jti-id',
+            'sub' => 'user-42',
+            'events' => [JwtLogoutTokenValidator::LOGOUT_EVENT_URI => []],
+        ]));
+
+        $this->jwksLoader->method('load')->willReturn($this->publicJwks());
+
+        // Signature verifies, but the expired `exp` must be rejected by the claim checker.
+        $this->expectException(InvalidTokenException::class);
+        $validator->validate($token);
+    }
+
     public function testValidateWithInvalidSignature(): void
     {
         $validator = new JwtLogoutTokenValidator($this->config, $this->jwksLoader, $this->clock);

--- a/tests/BackChannelLogout/LogoutTokenTest.php
+++ b/tests/BackChannelLogout/LogoutTokenTest.php
@@ -1,0 +1,243 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DigitalCz\OpenIDConnect\BackChannelLogout;
+
+use DigitalCz\OpenIDConnect\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use Stringable;
+use UnexpectedValueException;
+
+#[CoversClass(LogoutToken::class)]
+class LogoutTokenTest extends TestCase
+{
+    public function testConstructor(): void
+    {
+        $jwt = $this->createSampleLogoutJwt();
+        $token = new LogoutToken($jwt);
+
+        $this->assertSame($jwt, (string) $token);
+    }
+
+    public function testFromStringReturnsToken(): void
+    {
+        $jwt = $this->createSampleLogoutJwt();
+
+        $token = LogoutToken::from($jwt);
+
+        $this->assertInstanceOf(LogoutToken::class, $token);
+        $this->assertSame($jwt, (string) $token);
+    }
+
+    public function testFromArrayWithLogoutTokenKey(): void
+    {
+        $jwt = $this->createSampleLogoutJwt();
+
+        $token = LogoutToken::from(['logout_token' => $jwt]);
+
+        $this->assertSame($jwt, (string) $token);
+    }
+
+    public function testFromArrayWithoutLogoutTokenKeyThrows(): void
+    {
+        $this->expectException(UnexpectedValueException::class);
+        $this->expectExceptionMessage('Cannot create LogoutToken from array without "logout_token" key');
+
+        LogoutToken::from(['id_token' => 'foo']);
+    }
+
+    public function testFromStringable(): void
+    {
+        $jwt = $this->createSampleLogoutJwt();
+        $stringable = new class ($jwt) implements Stringable {
+            public function __construct(private string $value)
+            {
+            }
+
+            public function __toString(): string
+            {
+                return $this->value;
+            }
+        };
+
+        $token = LogoutToken::from($stringable);
+
+        $this->assertSame($jwt, (string) $token);
+    }
+
+    public function testFromNonStringThrows(): void
+    {
+        $this->expectException(UnexpectedValueException::class);
+
+        LogoutToken::from(123);
+    }
+
+    public function testFromInvalidJwtThrows(): void
+    {
+        $this->expectException(UnexpectedValueException::class);
+        $this->expectExceptionMessage('Invalid JWT logout token format');
+
+        LogoutToken::from('not-a-jwt');
+    }
+
+    public function testTryFromReturnsNullOnInvalid(): void
+    {
+        $this->assertNull(LogoutToken::tryFrom('not-a-jwt'));
+        $this->assertNull(LogoutToken::tryFrom(['foo' => 'bar']));
+        $this->assertNull(LogoutToken::tryFrom(123));
+    }
+
+    public function testTryFromReturnsTokenOnValid(): void
+    {
+        $jwt = $this->createSampleLogoutJwt();
+
+        $token = LogoutToken::tryFrom($jwt);
+
+        $this->assertInstanceOf(LogoutToken::class, $token);
+    }
+
+    public function testIss(): void
+    {
+        $jwt = $this->createSampleLogoutJwt(['iss' => 'https://op.example.com']);
+        $token = new LogoutToken($jwt);
+
+        $this->assertSame('https://op.example.com', $token->iss());
+    }
+
+    public function testAudAsString(): void
+    {
+        $jwt = $this->createSampleLogoutJwt(['aud' => 'client-id']);
+        $token = new LogoutToken($jwt);
+
+        $this->assertSame('client-id', $token->aud());
+    }
+
+    public function testAudAsArray(): void
+    {
+        $jwt = $this->createSampleLogoutJwt(['aud' => ['client-a', 'client-b']]);
+        $token = new LogoutToken($jwt);
+
+        $this->assertSame(['client-a', 'client-b'], $token->aud());
+    }
+
+    public function testIat(): void
+    {
+        $jwt = $this->createSampleLogoutJwt(['iat' => 1700000000]);
+        $token = new LogoutToken($jwt);
+
+        $this->assertSame(1700000000, $token->iat());
+    }
+
+    public function testJti(): void
+    {
+        $jwt = $this->createSampleLogoutJwt(['jti' => 'unique-jti-123']);
+        $token = new LogoutToken($jwt);
+
+        $this->assertSame('unique-jti-123', $token->jti());
+    }
+
+    public function testSubPresent(): void
+    {
+        $jwt = $this->createSampleLogoutJwt(['sub' => 'user-1']);
+        $token = new LogoutToken($jwt);
+
+        $this->assertSame('user-1', $token->sub());
+    }
+
+    public function testSubAbsent(): void
+    {
+        $payload = $this->sampleLogoutPayload();
+        unset($payload['sub']);
+        $jwt = $this->createCustomJwt(['typ' => 'JWT', 'alg' => 'RS256'], $payload);
+        $token = new LogoutToken($jwt);
+
+        $this->assertNull($token->sub());
+    }
+
+    public function testSidPresent(): void
+    {
+        $jwt = $this->createSampleLogoutJwt(['sid' => 'session-abc']);
+        $token = new LogoutToken($jwt);
+
+        $this->assertSame('session-abc', $token->sid());
+    }
+
+    public function testSidAbsent(): void
+    {
+        $jwt = $this->createSampleLogoutJwt(); // no sid by default
+        $token = new LogoutToken($jwt);
+
+        $this->assertNull($token->sid());
+    }
+
+    public function testEventsReturnsArray(): void
+    {
+        $events = [JwtLogoutTokenValidator::LOGOUT_EVENT_URI => (object) []];
+        $jwt = $this->createSampleLogoutJwt(['events' => $events]);
+        $token = new LogoutToken($jwt);
+
+        // object is decoded as empty array on JSON decode to associative
+        $this->assertArrayHasKey(JwtLogoutTokenValidator::LOGOUT_EVENT_URI, $token->events());
+    }
+
+    public function testEventsThrowsWhenMissing(): void
+    {
+        $payload = $this->sampleLogoutPayload();
+        unset($payload['events']);
+        $jwt = $this->createCustomJwt(['typ' => 'JWT', 'alg' => 'RS256'], $payload);
+        $token = new LogoutToken($jwt);
+
+        $this->expectException(UnexpectedValueException::class);
+
+        $token->events();
+    }
+
+    public function testClaims(): void
+    {
+        $jwt = $this->createSampleLogoutJwt(['sub' => 'user-42', 'sid' => 'sess-42']);
+        $token = new LogoutToken($jwt);
+
+        $claims = $token->claims();
+
+        $this->assertSame('user-42', $claims['sub']);
+        $this->assertSame('sess-42', $claims['sid']);
+    }
+
+    public function testToString(): void
+    {
+        $jwt = $this->createSampleLogoutJwt();
+        $token = new LogoutToken($jwt);
+
+        $this->assertSame($jwt, (string) $token);
+        $this->assertSame($jwt, $token->__toString());
+    }
+
+    /**
+     * @param array<string, mixed> $overrides
+     */
+    private function createSampleLogoutJwt(array $overrides = []): string
+    {
+        return $this->createCustomJwt(
+            ['typ' => 'logout+jwt', 'alg' => 'RS256', 'kid' => 'test-key-id'],
+            array_merge($this->sampleLogoutPayload(), $overrides),
+        );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function sampleLogoutPayload(): array
+    {
+        return [
+            'iss' => 'https://auth.example.com',
+            'aud' => 'test-client-id',
+            'iat' => time(),
+            'jti' => 'jti-12345',
+            'sub' => 'user-42',
+            'events' => [
+                JwtLogoutTokenValidator::LOGOUT_EVENT_URI => [],
+            ],
+        ];
+    }
+}

--- a/tests/Config/ClientMetadataTest.php
+++ b/tests/Config/ClientMetadataTest.php
@@ -23,6 +23,20 @@ class ClientMetadataTest extends TestCase
         $this->assertSame(['openid', 'profile', 'email'], $clientMetadata->defaultScopes());
         $this->assertSame(AuthenticationMethod::ClientSecretPost, $clientMetadata->authenticationMethod());
         $this->assertSame(PkceMethod::S256, $clientMetadata->pkceMethod());
+        $this->assertNull($clientMetadata->backchannelLogoutUri());
+        $this->assertFalse($clientMetadata->backchannelLogoutSessionRequired());
+    }
+
+    public function testBackchannelLogoutConfiguration(): void
+    {
+        $clientMetadata = new ClientMetadata(
+            clientId: 'test-client-id',
+            backchannelLogoutUri: 'https://rp.example.com/logout/backchannel',
+            backchannelLogoutSessionRequired: true,
+        );
+
+        $this->assertSame('https://rp.example.com/logout/backchannel', $clientMetadata->backchannelLogoutUri());
+        $this->assertTrue($clientMetadata->backchannelLogoutSessionRequired());
     }
 
     public function testConstructorWithAllParameters(): void

--- a/tests/Config/IssuerMetadataTest.php
+++ b/tests/Config/IssuerMetadataTest.php
@@ -166,6 +166,38 @@ class IssuerMetadataTest extends TestCase
         $this->assertSame($metadata, $issuerMetadata->claims());
     }
 
+    public function testBackchannelLogoutSupportedDefaultsToFalse(): void
+    {
+        $issuerMetadata = new IssuerMetadata($this->createSampleMetadata());
+
+        $this->assertFalse($issuerMetadata->backchannelLogoutSupported());
+        $this->assertFalse($issuerMetadata->backchannelLogoutSessionSupported());
+    }
+
+    public function testBackchannelLogoutSupportedTrue(): void
+    {
+        $metadata = $this->createSampleMetadata();
+        $metadata['backchannel_logout_supported'] = true;
+        $metadata['backchannel_logout_session_supported'] = true;
+
+        $issuerMetadata = new IssuerMetadata($metadata);
+
+        $this->assertTrue($issuerMetadata->backchannelLogoutSupported());
+        $this->assertTrue($issuerMetadata->backchannelLogoutSessionSupported());
+    }
+
+    public function testBackchannelLogoutSupportedFalse(): void
+    {
+        $metadata = $this->createSampleMetadata();
+        $metadata['backchannel_logout_supported'] = false;
+        $metadata['backchannel_logout_session_supported'] = false;
+
+        $issuerMetadata = new IssuerMetadata($metadata);
+
+        $this->assertFalse($issuerMetadata->backchannelLogoutSupported());
+        $this->assertFalse($issuerMetadata->backchannelLogoutSessionSupported());
+    }
+
     public function testClaimsTraitIntegration(): void
     {
         $metadata = [

--- a/tests/OidcFactoryTest.php
+++ b/tests/OidcFactoryTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace DigitalCz\OpenIDConnect;
 
+use DigitalCz\OpenIDConnect\BackChannelLogout\BackChannelLogoutHandler;
 use DigitalCz\OpenIDConnect\Client\AuthenticationMethod;
 use DigitalCz\OpenIDConnect\Client\AuthorizationCode;
 use DigitalCz\OpenIDConnect\Client\AuthorizationUrlResult;
@@ -45,6 +46,23 @@ class OidcFactoryTest extends TestCase
         $this->assertInstanceOf(AuthorizationCode::class, $oidc->authorizationCode());
         $this->assertInstanceOf(ClientCredentials::class, $oidc->clientCredentials());
         $this->assertInstanceOf(ResourceServer::class, $oidc->resourceServer());
+        $this->assertInstanceOf(BackChannelLogoutHandler::class, $oidc->backChannelLogout());
+    }
+
+    public function testCreateWithBackchannelLogoutParameters(): void
+    {
+        $oidc = OidcFactory::create(
+            httpClient: $this->httpClient,
+            issuer: $this->issuerMetadata,
+            clientId: 'test-client-id',
+            clientSecret: 'test-client-secret',
+            redirectUri: 'https://client.example.com/callback',
+            backchannelLogoutUri: 'https://client.example.com/logout/backchannel',
+            backchannelLogoutSessionRequired: true,
+        );
+
+        $this->assertInstanceOf(Oidc::class, $oidc);
+        $this->assertInstanceOf(BackChannelLogoutHandler::class, $oidc->backChannelLogout());
     }
 
     public function testCreateWithStaticIssuerMetadata(): void

--- a/tests/OidcTest.php
+++ b/tests/OidcTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace DigitalCz\OpenIDConnect;
 
+use DigitalCz\OpenIDConnect\BackChannelLogout\BackChannelLogoutHandler;
+use DigitalCz\OpenIDConnect\BackChannelLogout\JwtLogoutTokenValidator;
 use DigitalCz\OpenIDConnect\Client\AuthorizationCode;
 use DigitalCz\OpenIDConnect\Client\ClientCredentials;
 use DigitalCz\OpenIDConnect\Client\JwtIdTokenValidator;
@@ -25,6 +27,7 @@ class OidcTest extends TestCase
     private AuthorizationCode $authorizationCode;
     private ClientCredentials $clientCredentials;
     private ResourceServer $resourceServer;
+    private BackChannelLogoutHandler $backChannelLogout;
     private Config&MockObject $config;
     private HttpClientInterface $httpClient;
     private IssuerMetadata $issuerMetadata;
@@ -32,14 +35,24 @@ class OidcTest extends TestCase
 
     public function testConstructor(): void
     {
-        $oidc = new Oidc($this->authorizationCode, $this->clientCredentials, $this->resourceServer);
+        $oidc = new Oidc(
+            $this->authorizationCode,
+            $this->clientCredentials,
+            $this->resourceServer,
+            $this->backChannelLogout,
+        );
 
         $this->assertInstanceOf(Oidc::class, $oidc);
     }
 
     public function testAuthorizationCode(): void
     {
-        $oidc = new Oidc($this->authorizationCode, $this->clientCredentials, $this->resourceServer);
+        $oidc = new Oidc(
+            $this->authorizationCode,
+            $this->clientCredentials,
+            $this->resourceServer,
+            $this->backChannelLogout,
+        );
 
         $result = $oidc->authorizationCode();
 
@@ -49,7 +62,12 @@ class OidcTest extends TestCase
 
     public function testClientCredentials(): void
     {
-        $oidc = new Oidc($this->authorizationCode, $this->clientCredentials, $this->resourceServer);
+        $oidc = new Oidc(
+            $this->authorizationCode,
+            $this->clientCredentials,
+            $this->resourceServer,
+            $this->backChannelLogout,
+        );
 
         $result = $oidc->clientCredentials();
 
@@ -59,7 +77,12 @@ class OidcTest extends TestCase
 
     public function testResourceServer(): void
     {
-        $oidc = new Oidc($this->authorizationCode, $this->clientCredentials, $this->resourceServer);
+        $oidc = new Oidc(
+            $this->authorizationCode,
+            $this->clientCredentials,
+            $this->resourceServer,
+            $this->backChannelLogout,
+        );
 
         $result = $oidc->resourceServer();
 
@@ -67,9 +90,29 @@ class OidcTest extends TestCase
         $this->assertInstanceOf(ResourceServer::class, $result);
     }
 
+    public function testBackChannelLogout(): void
+    {
+        $oidc = new Oidc(
+            $this->authorizationCode,
+            $this->clientCredentials,
+            $this->resourceServer,
+            $this->backChannelLogout,
+        );
+
+        $result = $oidc->backChannelLogout();
+
+        $this->assertSame($this->backChannelLogout, $result);
+        $this->assertInstanceOf(BackChannelLogoutHandler::class, $result);
+    }
+
     public function testAllMethodsReturnSameInstancesConsistently(): void
     {
-        $oidc = new Oidc($this->authorizationCode, $this->clientCredentials, $this->resourceServer);
+        $oidc = new Oidc(
+            $this->authorizationCode,
+            $this->clientCredentials,
+            $this->resourceServer,
+            $this->backChannelLogout,
+        );
 
         // Test that multiple calls return the same instances
         $authCode1 = $oidc->authorizationCode();
@@ -83,39 +126,62 @@ class OidcTest extends TestCase
         $resourceServer1 = $oidc->resourceServer();
         $resourceServer2 = $oidc->resourceServer();
         $this->assertSame($resourceServer1, $resourceServer2);
+
+        $backChannelLogout1 = $oidc->backChannelLogout();
+        $backChannelLogout2 = $oidc->backChannelLogout();
+        $this->assertSame($backChannelLogout1, $backChannelLogout2);
     }
 
     public function testReadonlyClassBehavior(): void
     {
-        $oidc = new Oidc($this->authorizationCode, $this->clientCredentials, $this->resourceServer);
+        $oidc = new Oidc(
+            $this->authorizationCode,
+            $this->clientCredentials,
+            $this->resourceServer,
+            $this->backChannelLogout,
+        );
 
         // Test that the class is readonly by verifying constructor injection works
         $this->assertSame($this->authorizationCode, $oidc->authorizationCode());
         $this->assertSame($this->clientCredentials, $oidc->clientCredentials());
         $this->assertSame($this->resourceServer, $oidc->resourceServer());
+        $this->assertSame($this->backChannelLogout, $oidc->backChannelLogout());
 
         // The readonly class should maintain state consistently
-        $oidc2 = new Oidc($this->authorizationCode, $this->clientCredentials, $this->resourceServer);
+        $oidc2 = new Oidc(
+            $this->authorizationCode,
+            $this->clientCredentials,
+            $this->resourceServer,
+            $this->backChannelLogout,
+        );
 
         $this->assertSame($oidc->authorizationCode(), $oidc2->authorizationCode());
         $this->assertSame($oidc->clientCredentials(), $oidc2->clientCredentials());
         $this->assertSame($oidc->resourceServer(), $oidc2->resourceServer());
+        $this->assertSame($oidc->backChannelLogout(), $oidc2->backChannelLogout());
     }
 
     public function testFacadePattern(): void
     {
         // Test that Oidc acts as a proper facade providing access to all sub-components
-        $oidc = new Oidc($this->authorizationCode, $this->clientCredentials, $this->resourceServer);
+        $oidc = new Oidc(
+            $this->authorizationCode,
+            $this->clientCredentials,
+            $this->resourceServer,
+            $this->backChannelLogout,
+        );
 
-        // Verify facade provides access to all three main components
+        // Verify facade provides access to all main components
         $this->assertInstanceOf(AuthorizationCode::class, $oidc->authorizationCode());
         $this->assertInstanceOf(ClientCredentials::class, $oidc->clientCredentials());
         $this->assertInstanceOf(ResourceServer::class, $oidc->resourceServer());
+        $this->assertInstanceOf(BackChannelLogoutHandler::class, $oidc->backChannelLogout());
 
         // Verify each component is accessible and distinct
         $this->assertNotSame($oidc->authorizationCode(), $oidc->clientCredentials());
         $this->assertNotSame($oidc->authorizationCode(), $oidc->resourceServer());
         $this->assertNotSame($oidc->clientCredentials(), $oidc->resourceServer());
+        $this->assertNotSame($oidc->backChannelLogout(), $oidc->resourceServer());
     }
 
     public function testWithDifferentImplementations(): void
@@ -144,14 +210,21 @@ class OidcTest extends TestCase
         $authCode2 = new AuthorizationCode($config2, $this->httpClient, $idTokenValidator2);
         $clientCreds2 = new ClientCredentials($config2, $this->httpClient);
         $resourceServer2 = new ResourceServer([]);
+        $backChannelLogout2 = new BackChannelLogoutHandler(new JwtLogoutTokenValidator($config2, $jwksLoader2));
 
-        $oidc1 = new Oidc($this->authorizationCode, $this->clientCredentials, $this->resourceServer);
-        $oidc2 = new Oidc($authCode2, $clientCreds2, $resourceServer2);
+        $oidc1 = new Oidc(
+            $this->authorizationCode,
+            $this->clientCredentials,
+            $this->resourceServer,
+            $this->backChannelLogout,
+        );
+        $oidc2 = new Oidc($authCode2, $clientCreds2, $resourceServer2, $backChannelLogout2);
 
         // Verify each Oidc instance maintains its own dependencies
         $this->assertNotSame($oidc1->authorizationCode(), $oidc2->authorizationCode());
         $this->assertNotSame($oidc1->clientCredentials(), $oidc2->clientCredentials());
         $this->assertNotSame($oidc1->resourceServer(), $oidc2->resourceServer());
+        $this->assertNotSame($oidc1->backChannelLogout(), $oidc2->backChannelLogout());
 
         // Verify that the instances are properly typed
         $this->assertInstanceOf(AuthorizationCode::class, $oidc1->authorizationCode());
@@ -160,6 +233,8 @@ class OidcTest extends TestCase
         $this->assertInstanceOf(ClientCredentials::class, $oidc2->clientCredentials());
         $this->assertInstanceOf(ResourceServer::class, $oidc1->resourceServer());
         $this->assertInstanceOf(ResourceServer::class, $oidc2->resourceServer());
+        $this->assertInstanceOf(BackChannelLogoutHandler::class, $oidc1->backChannelLogout());
+        $this->assertInstanceOf(BackChannelLogoutHandler::class, $oidc2->backChannelLogout());
     }
 
     protected function setUp(): void
@@ -195,6 +270,10 @@ class OidcTest extends TestCase
         $jwtValidator = new JwtAccessTokenValidator($this->config, $jwksLoader, $this->clientMetadata->clientId());
 
         $this->resourceServer = new ResourceServer([$jwtValidator, $opaqueValidator]);
+
+        $this->backChannelLogout = new BackChannelLogoutHandler(
+            new JwtLogoutTokenValidator($this->config, $jwksLoader),
+        );
     }
 
     private function createRealIssuerMetadata(): IssuerMetadata


### PR DESCRIPTION
## Summary

Implements [OpenID Connect Back-Channel Logout 1.0](https://openid.net/specs/openid-connect-backchannel-1_0.html)
so Relying Parties can process server-to-server logout notifications from the OpenID Provider.

The OP POSTs a `logout_token` to the RP's back-channel logout endpoint; the application passes it to the new handler,
which verifies the signature against the issuer JWKS and validates the logout-token claims. The application remains
responsible for `jti` replay protection and for terminating the matching session(s).

## What's included

- **New `BackChannelLogout` namespace:**
  - `LogoutToken` — value object exposing `iss`/`aud`/`iat`/`jti`/`sub`/`sid`/`events`.
  - `LogoutTokenValidator` interface + `JwtLogoutTokenValidator` implementation. Mirrors `JwtIdTokenValidator`:
    JWKS-backed signature verification, standard claim checks (`iss`, `aud`, `iat`, `exp`/`nbf` when present), and
    logout-specific rules per §2.6 — `events` contains the backchannel-logout URI, `nonce` MUST NOT be present, and
    at least one of `sub`/`sid` MUST be present.
  - `BackChannelLogoutHandler` — entry point (`handleLogoutRequest()`).
- **Facade/factory wiring:** `Oidc::backChannelLogout()` and the corresponding `OidcFactory::create()` parameters.
- **Config:** `ClientMetadata` gains `backchannelLogoutUri` and `backchannelLogoutSessionRequired`; `IssuerMetadata`
  gains the `backchannelLogoutSupported` / `backchannelLogoutSessionSupported` discovery getters.
- **`backchannel_logout_session_required` enforced:** when the client registers it, logout tokens without a `sid`
  claim are rejected (per the client-registration metadata definition in the spec).
- **Docs & examples:** README Back-Channel Logout section + config options, and a runnable
  `examples/backchannel_logout.php`.

## Not handled (left to the application, by design)

- **Replay protection** — `jti` is exposed; the app should reject recently-seen `jti` values.
- **Session termination** — the app maps `sid`/`sub` to its session store and destroys the relevant session(s).

## Notes

- Rebased onto current `1.x`, so signature verification builds on the transport/issuer/audience hardening from #85.
- Full check suite green; `JwtLogoutTokenValidator` is at 100% line coverage.

Refs #50
