### PR TITLE
Order caught exception types alphabetically

### DIFF
--- a/src/Discovery/HttpDiscoverer.php
+++ b/src/Discovery/HttpDiscoverer.php
@@ -38,7 +38,7 @@ final class HttpDiscoverer implements Discoverer
             $response = $this->httpClient->request('GET', $discoveryUrl)->toArray();
         } catch (TransportExceptionInterface $e) {
             throw new NetworkException('Failed to fetch OIDC discovery document: ' . $e->getMessage(), 0, $e);
-        } catch (ClientExceptionInterface | ServerExceptionInterface | RedirectionExceptionInterface $e) {
+        } catch (ClientExceptionInterface | RedirectionExceptionInterface | ServerExceptionInterface $e) {
             throw new DiscoveryException('OIDC discovery endpoint returned error: ' . $e->getMessage(), 0, $e);
         } catch (DecodingExceptionInterface $e) {
             throw new DiscoveryException('Failed to decode OIDC discovery document: ' . $e->getMessage(), 0, $e);

--- a/src/Discovery/HttpJwksLoader.php
+++ b/src/Discovery/HttpJwksLoader.php
@@ -36,7 +36,7 @@ final readonly class HttpJwksLoader implements JwksLoader
             return $this->httpClient->request('GET', $jwksUri)->toArray();
         } catch (TransportExceptionInterface $e) {
             throw new NetworkException('Failed to fetch JWKS document: ' . $e->getMessage(), 0, $e);
-        } catch (ClientExceptionInterface | ServerExceptionInterface | RedirectionExceptionInterface $e) {
+        } catch (ClientExceptionInterface | RedirectionExceptionInterface | ServerExceptionInterface $e) {
             throw new DiscoveryException('JWKS endpoint returned error: ' . $e->getMessage(), 0, $e);
         } catch (DecodingExceptionInterface $e) {
             throw new DiscoveryException('Failed to decode JWKS document: ' . $e->getMessage(), 0, $e);


### PR DESCRIPTION
Adds compliance with the `SlevomatCodingStandard.Exceptions.CatchExceptionsOrder` sniff introduced in `digitalcz/coding-standard` 0.6.0, which requires multi-catch exception types to be alphabetically ordered.

Reorders the two affected catch blocks (`Client | Server | Redirection` → `Client | Redirection | Server`):
- `src/Discovery/HttpDiscoverer.php`
- `src/Discovery/HttpJwksLoader.php`

This unblocks the coding-standard bump in #86. The change is behaviour-neutral and harmless under 0.5.x.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
