### PR TITLE
Harden JWT signature algorithm allow-list (restrict to asymmetric, per RFC 8725)

### DIFF
--- a/src/BackChannelLogout/JwtLogoutTokenValidator.php
+++ b/src/BackChannelLogout/JwtLogoutTokenValidator.php
@@ -136,7 +136,10 @@ final class JwtLogoutTokenValidator implements LogoutTokenValidator
 
     private function createJwsLoader(): JWSLoader
     {
-        $signingAlgorithms = $this->config->issuerMetadata()->idTokenSigningAlgValuesSupported();
+        $signingAlgorithms = array_values(array_intersect(
+            $this->config->issuerMetadata()->idTokenSigningAlgValuesSupported(),
+            SignatureAlgorithmsFactory::asymmetricAlgorithmNames(),
+        ));
         $algorithmManagerFactory = new AlgorithmManagerFactory(SignatureAlgorithmsFactory::create());
 
         return $this->jwsLoader ??= new JWSLoader(

--- a/src/BackChannelLogout/JwtLogoutTokenValidator.php
+++ b/src/BackChannelLogout/JwtLogoutTokenValidator.php
@@ -136,10 +136,9 @@ final class JwtLogoutTokenValidator implements LogoutTokenValidator
 
     private function createJwsLoader(): JWSLoader
     {
-        $signingAlgorithms = array_values(array_intersect(
+        $signingAlgorithms = SignatureAlgorithmsFactory::restrictToAsymmetric(
             $this->config->issuerMetadata()->idTokenSigningAlgValuesSupported(),
-            SignatureAlgorithmsFactory::asymmetricAlgorithmNames(),
-        ));
+        );
         $algorithmManagerFactory = new AlgorithmManagerFactory(SignatureAlgorithmsFactory::create());
 
         return $this->jwsLoader ??= new JWSLoader(

--- a/src/Client/JwtIdTokenValidator.php
+++ b/src/Client/JwtIdTokenValidator.php
@@ -82,7 +82,10 @@ final class JwtIdTokenValidator implements IdTokenValidator
 
     private function createJwsLoader(): JWSLoader
     {
-        $idTokenSigningAlgorithms = $this->config->issuerMetadata()->idTokenSigningAlgValuesSupported();
+        $idTokenSigningAlgorithms = array_values(array_intersect(
+            $this->config->issuerMetadata()->idTokenSigningAlgValuesSupported(),
+            SignatureAlgorithmsFactory::asymmetricAlgorithmNames(),
+        ));
         $algorithmManagerFactory = new AlgorithmManagerFactory(SignatureAlgorithmsFactory::create());
 
         return $this->jwsLoader ??= new JWSLoader(

--- a/src/Client/JwtIdTokenValidator.php
+++ b/src/Client/JwtIdTokenValidator.php
@@ -82,10 +82,9 @@ final class JwtIdTokenValidator implements IdTokenValidator
 
     private function createJwsLoader(): JWSLoader
     {
-        $idTokenSigningAlgorithms = array_values(array_intersect(
+        $idTokenSigningAlgorithms = SignatureAlgorithmsFactory::restrictToAsymmetric(
             $this->config->issuerMetadata()->idTokenSigningAlgValuesSupported(),
-            SignatureAlgorithmsFactory::asymmetricAlgorithmNames(),
-        ));
+        );
         $algorithmManagerFactory = new AlgorithmManagerFactory(SignatureAlgorithmsFactory::create());
 
         return $this->jwsLoader ??= new JWSLoader(

--- a/src/ResourceServer/JwtAccessTokenValidator.php
+++ b/src/ResourceServer/JwtAccessTokenValidator.php
@@ -123,7 +123,10 @@ final class JwtAccessTokenValidator implements AccessTokenValidator
 
     private function createJwsLoader(): JWSLoader
     {
-        $idTokenSigningAlgorithms = $this->config->issuerMetadata()->idTokenSigningAlgValuesSupported();
+        $idTokenSigningAlgorithms = array_values(array_intersect(
+            $this->config->issuerMetadata()->idTokenSigningAlgValuesSupported(),
+            SignatureAlgorithmsFactory::asymmetricAlgorithmNames(),
+        ));
         $algorithmManagerFactory = new AlgorithmManagerFactory(SignatureAlgorithmsFactory::create());
 
         return $this->jwsLoader ??= new JWSLoader(

--- a/src/ResourceServer/JwtAccessTokenValidator.php
+++ b/src/ResourceServer/JwtAccessTokenValidator.php
@@ -123,10 +123,9 @@ final class JwtAccessTokenValidator implements AccessTokenValidator
 
     private function createJwsLoader(): JWSLoader
     {
-        $idTokenSigningAlgorithms = array_values(array_intersect(
+        $idTokenSigningAlgorithms = SignatureAlgorithmsFactory::restrictToAsymmetric(
             $this->config->issuerMetadata()->idTokenSigningAlgValuesSupported(),
-            SignatureAlgorithmsFactory::asymmetricAlgorithmNames(),
-        ));
+        );
         $algorithmManagerFactory = new AlgorithmManagerFactory(SignatureAlgorithmsFactory::create());
 
         return $this->jwsLoader ??= new JWSLoader(

--- a/src/Util/SignatureAlgorithmsFactory.php
+++ b/src/Util/SignatureAlgorithmsFactory.php
@@ -26,15 +26,25 @@ use Jose\Component\Signature\Algorithm\RS512;
 final class SignatureAlgorithmsFactory
 {
     /**
+     * Symmetric (HMAC) signature algorithms.
+     *
      * @var array<int, class-string<Algorithm>>
      */
-    private static array $algorithms = [
-        ES256::class,
-        ES384::class,
-        ES512::class,
+    private static array $symmetricAlgorithms = [
         HS256::class,
         HS384::class,
         HS512::class,
+    ];
+
+    /**
+     * Asymmetric (public-key) signature algorithms.
+     *
+     * @var array<int, class-string<Algorithm>>
+     */
+    private static array $asymmetricAlgorithms = [
+        ES256::class,
+        ES384::class,
+        ES512::class,
         EdDSA::class,
         PS256::class,
         PS384::class,
@@ -51,12 +61,36 @@ final class SignatureAlgorithmsFactory
      */
     public static function create(): Generator
     {
-        foreach (self::$algorithms as $class) {
+        foreach ([...self::$symmetricAlgorithms, ...self::$asymmetricAlgorithms] as $class) {
             if (class_exists($class)) {
                 $algorithm = new $class();
 
                 yield $algorithm->name() => $algorithm;
             }
         }
+    }
+
+    /**
+     * Names of the available asymmetric (public-key) signature algorithms.
+     *
+     * Verification of tokens against a provider JWKS must be restricted to these,
+     * never accepting HMAC, per RFC 8725 §3.1 — defense-in-depth against
+     * algorithm-confusion attacks.
+     *
+     * @return list<string>
+     *
+     * @see https://www.rfc-editor.org/rfc/rfc8725#section-3.1
+     */
+    public static function asymmetricAlgorithmNames(): array
+    {
+        $names = [];
+
+        foreach (self::$asymmetricAlgorithms as $class) {
+            if (class_exists($class)) {
+                $names[] = (new $class())->name();
+            }
+        }
+
+        return $names;
     }
 }

--- a/src/Util/SignatureAlgorithmsFactory.php
+++ b/src/Util/SignatureAlgorithmsFactory.php
@@ -93,4 +93,20 @@ final class SignatureAlgorithmsFactory
 
         return $names;
     }
+
+    /**
+     * Restrict a list of advertised algorithm names to the available asymmetric ones.
+     *
+     * Verification of tokens against a provider JWKS must never accept HMAC,
+     * per RFC 8725 §3.1 — defense-in-depth against algorithm-confusion attacks.
+     *
+     * @param array<string> $algorithms
+     * @return list<string>
+     *
+     * @see https://www.rfc-editor.org/rfc/rfc8725#section-3.1
+     */
+    public static function restrictToAsymmetric(array $algorithms): array
+    {
+        return array_values(array_intersect($algorithms, self::asymmetricAlgorithmNames()));
+    }
 }

--- a/tests/BackChannelLogout/JwtLogoutTokenValidatorTest.php
+++ b/tests/BackChannelLogout/JwtLogoutTokenValidatorTest.php
@@ -341,6 +341,40 @@ class JwtLogoutTokenValidatorTest extends TestCase
         $validator->validate($token);
     }
 
+    public function testValidateRejectsHs256TokenEvenWhenAdvertised(): void
+    {
+        // The OP (mis)advertises a symmetric algorithm alongside its JWKS, and the
+        // rogue JWKS even exposes the matching HMAC secret as an `oct` key — so only
+        // the asymmetric algorithm allow-list (RFC 8725 §3.1), not web-token's
+        // key-type binding, can reject this logout token.
+        $issuerMetadata = new IssuerMetadata([
+            'issuer' => 'https://auth.example.com',
+            'jwks_uri' => 'https://auth.example.com/.well-known/jwks.json',
+            'id_token_signing_alg_values_supported' => ['RS256', 'HS256'],
+        ]);
+
+        $config = $this->createMock(Config::class);
+        $config->method('issuerMetadata')->willReturn($issuerMetadata);
+        $config->method('clientMetadata')->willReturn($this->clientMetadata);
+
+        $this->jwksLoader->method('load')->willReturn($this->symmetricJwks());
+
+        $validator = new JwtLogoutTokenValidator($config, $this->jwksLoader, $this->clock);
+
+        $token = new LogoutToken($this->createHs256Jwt([
+            'iss' => 'https://auth.example.com',
+            'aud' => 'test-client-id',
+            'jti' => 'unique-jti-id',
+            'sub' => 'user-42',
+            'events' => [JwtLogoutTokenValidator::LOGOUT_EVENT_URI => []],
+        ]));
+
+        $this->expectException(InvalidTokenException::class);
+        $this->expectExceptionMessage('Invalid Logout Token:');
+
+        $validator->validate($token);
+    }
+
     protected function setUp(): void
     {
         parent::setUp();

--- a/tests/Client/JwtIdTokenValidatorTest.php
+++ b/tests/Client/JwtIdTokenValidatorTest.php
@@ -410,6 +410,37 @@ class JwtIdTokenValidatorTest extends TestCase
         $validator->validate(new IdToken($jwt));
     }
 
+    public function testRejectsHs256TokenEvenWhenAdvertised(): void
+    {
+        // The OP (mis)advertises a symmetric algorithm alongside its JWKS, and the
+        // rogue JWKS even exposes the matching HMAC secret as an `oct` key — so only
+        // the asymmetric algorithm allow-list (RFC 8725 §3.1), not web-token's
+        // key-type binding, can reject this token.
+        $issuerMetadata = new IssuerMetadata([
+            'issuer' => 'https://auth.example.com',
+            'jwks_uri' => 'https://auth.example.com/.well-known/jwks.json',
+            'id_token_signing_alg_values_supported' => ['RS256', 'HS256'],
+        ]);
+
+        $config = $this->createMock(Config::class);
+        $config->method('issuerMetadata')->willReturn($issuerMetadata);
+        $config->method('clientMetadata')->willReturn($this->clientMetadata);
+
+        $this->jwksLoader->method('load')->willReturn($this->symmetricJwks());
+
+        $validator = new JwtIdTokenValidator($config, $this->jwksLoader);
+
+        $jwt = $this->createHs256Jwt([
+            'iss' => 'https://auth.example.com',
+            'aud' => 'test-client-id',
+        ]);
+
+        $this->expectException(InvalidTokenException::class);
+        $this->expectExceptionMessage('Invalid ID Token:');
+
+        $validator->validate(new IdToken($jwt));
+    }
+
     protected function setUp(): void
     {
         parent::setUp();

--- a/tests/ResourceServer/JwtAccessTokenValidatorTest.php
+++ b/tests/ResourceServer/JwtAccessTokenValidatorTest.php
@@ -671,6 +671,36 @@ class JwtAccessTokenValidatorTest extends TestCase
         $validator->validate(new JwtAccessToken($jwt));
     }
 
+    public function testRejectsHs256TokenEvenWhenAdvertised(): void
+    {
+        // The OP (mis)advertises a symmetric algorithm alongside its JWKS, and the
+        // rogue JWKS even exposes the matching HMAC secret as an `oct` key — so only
+        // the asymmetric algorithm allow-list (RFC 8725 §3.1), not web-token's
+        // key-type binding, can reject this token.
+        $issuerMetadata = new IssuerMetadata([
+            'issuer' => 'https://auth.example.com',
+            'jwks_uri' => 'https://auth.example.com/.well-known/jwks.json',
+            'id_token_signing_alg_values_supported' => ['RS256', 'HS256'],
+        ]);
+
+        $config = $this->createMock(Config::class);
+        $config->method('issuerMetadata')->willReturn($issuerMetadata);
+
+        $this->jwksLoader->method('load')->willReturn($this->symmetricJwks());
+
+        $validator = new JwtAccessTokenValidator($config, $this->jwksLoader, 'test-audience', new SimpleClock());
+
+        $jwt = $this->createHs256Jwt([
+            'iss' => 'https://auth.example.com',
+            'aud' => 'test-audience',
+        ]);
+
+        $this->expectException(InvalidTokenException::class);
+        $this->expectExceptionMessage('Invalid Access Token:');
+
+        $validator->validate(new JwtAccessToken($jwt));
+    }
+
     protected function setUp(): void
     {
         parent::setUp();

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -17,6 +17,7 @@ use PHPUnit\Framework\TestCase as BaseTestCase;
 abstract class TestCase extends BaseTestCase
 {
     private ?JWK $signingKey = null;
+    private ?JWK $symmetricKey = null;
 
     /**
      * Create a sample JWT token for testing
@@ -191,6 +192,61 @@ abstract class TestCase extends BaseTestCase
             ->create()
             ->withPayload(Json::encode($payload))
             ->addSignature($this->signingKey(), $header)
+            ->build();
+
+        return (new CompactSerializer())->serialize($jws, 0);
+    }
+
+    /**
+     * The HMAC secret used to sign symmetric (HS256) JWTs in tests.
+     */
+    protected function symmetricKey(): JWK
+    {
+        return $this->symmetricKey ??= JWKFactory::createFromSecret(
+            'this-is-a-shared-secret-used-only-in-tests-32b',
+            ['alg' => 'HS256', 'use' => 'sig', 'kid' => 'hs-key-id'],
+        );
+    }
+
+    /**
+     * A rogue JWKS exposing the HMAC secret as an `oct` key (see {@see symmetricKey()}).
+     *
+     * Used to prove that HS256 tokens are rejected by the algorithm allow-list even
+     * when a matching key is present — not merely by web-token's key-type binding.
+     *
+     * @return array<string, mixed>
+     */
+    protected function symmetricJwks(): array
+    {
+        return ['keys' => [$this->symmetricKey()->all()]];
+    }
+
+    /**
+     * Create an HS256-signed compact JWT (RFC 8725 algorithm-confusion test vector).
+     *
+     * @param array<string, mixed> $payload
+     */
+    protected function createHs256Jwt(array $payload = []): string
+    {
+        $defaultPayload = [
+            'iss' => 'https://auth.example.com',
+            'sub' => '1234567890',
+            'aud' => 'test-audience',
+            'exp' => time() + 3600,
+            'iat' => time(),
+        ];
+
+        $payload = array_filter(
+            array_merge($defaultPayload, $payload),
+            static fn (mixed $value): bool => $value !== null,
+        );
+
+        $algorithmManager = (new AlgorithmManagerFactory(SignatureAlgorithmsFactory::create()))->create(['HS256']);
+
+        $jws = (new JWSBuilder($algorithmManager))
+            ->create()
+            ->withPayload(Json::encode($payload))
+            ->addSignature($this->symmetricKey(), ['typ' => 'JWT', 'alg' => 'HS256', 'kid' => 'hs-key-id'])
             ->build();
 
         return (new CompactSerializer())->serialize($jws, 0);

--- a/tests/Util/SignatureAlgorithmsFactoryTest.php
+++ b/tests/Util/SignatureAlgorithmsFactoryTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DigitalCz\OpenIDConnect\Util;
+
+use DigitalCz\OpenIDConnect\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+#[CoversClass(SignatureAlgorithmsFactory::class)]
+class SignatureAlgorithmsFactoryTest extends TestCase
+{
+    public function testCreateRegistersBothSymmetricAndAsymmetricAlgorithms(): void
+    {
+        $names = array_keys(iterator_to_array(SignatureAlgorithmsFactory::create()));
+
+        $this->assertContains('RS256', $names);
+        $this->assertContains('ES256', $names);
+        $this->assertContains('EdDSA', $names);
+        $this->assertContains('HS256', $names); // still available for client_secret_jwt signing
+    }
+
+    public function testAsymmetricAlgorithmNamesExcludeHmac(): void
+    {
+        $names = SignatureAlgorithmsFactory::asymmetricAlgorithmNames();
+
+        $this->assertContains('RS256', $names);
+        $this->assertContains('PS256', $names);
+        $this->assertContains('ES256', $names);
+        $this->assertContains('EdDSA', $names);
+
+        $this->assertNotContains('HS256', $names);
+        $this->assertNotContains('HS384', $names);
+        $this->assertNotContains('HS512', $names);
+    }
+}

--- a/tests/Util/SignatureAlgorithmsFactoryTest.php
+++ b/tests/Util/SignatureAlgorithmsFactoryTest.php
@@ -33,4 +33,16 @@ class SignatureAlgorithmsFactoryTest extends TestCase
         $this->assertNotContains('HS384', $names);
         $this->assertNotContains('HS512', $names);
     }
+
+    public function testRestrictToAsymmetricDropsHmacAndKeepsAsymmetric(): void
+    {
+        $restricted = SignatureAlgorithmsFactory::restrictToAsymmetric(['HS256', 'RS256', 'ES256', 'HS512']);
+
+        $this->assertSame(['RS256', 'ES256'], $restricted);
+    }
+
+    public function testRestrictToAsymmetricReturnsEmptyListWhenOnlyHmacAdvertised(): void
+    {
+        $this->assertSame([], SignatureAlgorithmsFactory::restrictToAsymmetric(['HS256', 'HS384']));
+    }
 }


### PR DESCRIPTION
Closes #88.

## What

The three JWT validators built their algorithm allow-list directly from the provider's advertised `id_token_signing_alg_values_supported`, which `SignatureAlgorithmsFactory` could resolve to a mix of symmetric (`HS*`) and asymmetric (`RS*`/`PS*`/`ES*`/`EdDSA`) algorithms.

This restricts token verification to **asymmetric algorithms only**, per [RFC 8725 §3.1](https://www.rfc-editor.org/rfc/rfc8725#section-3.1) — defense-in-depth against algorithm-confusion attacks, removing the foot-gun rather than relying on `web-token`'s key-type binding.

## Changes

- **`SignatureAlgorithmsFactory`** — split the algorithm list into symmetric / asymmetric sets (no duplication) and added `asymmetricAlgorithmNames()`. `create()` still registers **all** algorithms, so `client_secret_jwt` (HS256) client-assertion signing in `JwtClientAssertionGenerator` keeps working.
- **`JwtIdTokenValidator`, `JwtAccessTokenValidator`, `JwtLogoutTokenValidator`** — each intersects the advertised allow-list with the asymmetric names before building the `JWSVerifier` and `AlgorithmChecker`.

## Tests

- A hardening test per validator: the OP advertises `HS256` **and** the (rogue) JWKS exposes the matching HMAC secret as an `oct` key — proving the token is rejected by the **algorithm allow-list**, not merely by key-type binding. Verified these fail without the fix.
- Unit test for `SignatureAlgorithmsFactory` (HMAC excluded from asymmetric names).
- Shared `TestCase` helpers: `symmetricKey()`, `symmetricJwks()`, `createHs256Jwt()`.

`composer checks` is green (phpcs ✓, phpstan ✓, 594 tests ✓).

## ⚠️ Breaking change

HS256-signed ID / access / logout tokens are no longer accepted. Anyone relying on HMAC-signed tokens from their OP will now get an `InvalidTokenException`. Should target a **minor** at minimum.

🤖 Generated with [Claude Code](https://claude.com/claude-code)