### PR TITLE
Enforce @throws for checked exceptions via PHPStan

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -3,3 +3,9 @@ parameters:
     paths:
         - src
         - examples
+    exceptions:
+        check:
+            missingCheckedExceptionInThrows: true
+            tooWideThrowType: true
+        checkedExceptionClasses:
+            - DigitalCz\OpenIDConnect\Exception\Exception

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -8,4 +8,9 @@ parameters:
             missingCheckedExceptionInThrows: true
             tooWideThrowType: true
         checkedExceptionClasses:
+            # All of the library's own exceptions.
             - DigitalCz\OpenIDConnect\Exception\Exception
+            # Symfony HTTP client exceptions are checked so that every call site is forced to
+            # either handle them (wrap into one of our own exceptions) or declare them - the
+            # library never lets a raw Symfony exception leak out of its public API.
+            - Symfony\Contracts\HttpClient\Exception\ExceptionInterface

--- a/src/BackChannelLogout/JwtLogoutTokenValidator.php
+++ b/src/BackChannelLogout/JwtLogoutTokenValidator.php
@@ -6,7 +6,9 @@ namespace DigitalCz\OpenIDConnect\BackChannelLogout;
 
 use DigitalCz\OpenIDConnect\Config\Config;
 use DigitalCz\OpenIDConnect\Discovery\JwksLoader;
+use DigitalCz\OpenIDConnect\Exception\DiscoveryException;
 use DigitalCz\OpenIDConnect\Exception\InvalidTokenException;
+use DigitalCz\OpenIDConnect\Exception\NetworkException;
 use DigitalCz\OpenIDConnect\Util\SignatureAlgorithmsFactory;
 use DigitalCz\OpenIDConnect\Util\SimpleClock;
 use Exception;
@@ -134,6 +136,10 @@ final class JwtLogoutTokenValidator implements LogoutTokenValidator
         }
     }
 
+    /**
+     * @throws DiscoveryException if provider metadata cannot be resolved
+     * @throws NetworkException if the discovery endpoint cannot be reached
+     */
     private function createJwsLoader(): JWSLoader
     {
         $signingAlgorithms = $this->config->issuerMetadata()->idTokenSigningAlgValuesSupported();
@@ -146,11 +152,19 @@ final class JwtLogoutTokenValidator implements LogoutTokenValidator
         );
     }
 
+    /**
+     * @throws DiscoveryException if provider metadata cannot be resolved
+     * @throws NetworkException if the discovery endpoint cannot be reached
+     */
     private function validateClaims(LogoutToken $token): void
     {
         $this->createClaimCheckerManager()->check($token->claims(), $this->mandatoryClaims);
     }
 
+    /**
+     * @throws DiscoveryException if provider metadata cannot be resolved
+     * @throws NetworkException if the discovery endpoint cannot be reached
+     */
     private function createClaimCheckerManager(): ClaimCheckerManager
     {
         return $this->claimCheckerManager ??= new ClaimCheckerManager([

--- a/src/Client/AuthorizationCode.php
+++ b/src/Client/AuthorizationCode.php
@@ -5,6 +5,9 @@ declare(strict_types=1);
 namespace DigitalCz\OpenIDConnect\Client;
 
 use DigitalCz\OpenIDConnect\Config\Config;
+use DigitalCz\OpenIDConnect\Exception\DiscoveryException;
+use DigitalCz\OpenIDConnect\Exception\InvalidTokenException;
+use DigitalCz\OpenIDConnect\Exception\NetworkException;
 use DigitalCz\OpenIDConnect\Util\Pkce;
 use InvalidArgumentException;
 use RuntimeException;
@@ -34,6 +37,9 @@ final readonly class AuthorizationCode
      *
      * @param array<string, string> $params Additional query parameters
      * @return AuthorizationUrlResult Authorization URL with security parameters
+     *
+     * @throws DiscoveryException if provider metadata cannot be resolved
+     * @throws NetworkException if the discovery endpoint cannot be reached
      */
     public function createAuthorizationUrl(array $params = []): AuthorizationUrlResult
     {
@@ -78,6 +84,9 @@ final readonly class AuthorizationCode
      *
      * @param array<string, string> $params Additional query parameters
      * @return string Logout URL with query parameters
+     *
+     * @throws DiscoveryException if provider metadata cannot be resolved
+     * @throws NetworkException if the discovery endpoint cannot be reached
      */
     public function createLogoutUrl(array $params = []): string
     {
@@ -99,6 +108,10 @@ final readonly class AuthorizationCode
      * @param string|null $codeVerifier PKCE code verifier (required if PKCE was used)
      * @param array<string, string> $params Additional body parameters
      * @return Tokens Access token, refresh token, and ID token
+     *
+     * @throws DiscoveryException if provider metadata cannot be resolved
+     * @throws InvalidTokenException if the returned ID token fails validation
+     * @throws NetworkException if the token endpoint cannot be reached
      */
     public function fetchTokens(
         string $code,
@@ -131,6 +144,9 @@ final readonly class AuthorizationCode
      * @param Tokens $tokens Current tokens with refresh token
      * @param array<string, string> $params Additional body parameters
      * @return Tokens New tokens with fresh access token
+     *
+     * @throws DiscoveryException if provider metadata cannot be resolved
+     * @throws NetworkException if the token endpoint cannot be reached
      */
     public function refreshToken(Tokens $tokens, array $params = []): Tokens
     {
@@ -158,6 +174,9 @@ final readonly class AuthorizationCode
      *
      * @param Tokens $tokens Tokens with access token
      * @return Userinfo User profile information
+     *
+     * @throws DiscoveryException if provider metadata cannot be resolved
+     * @throws NetworkException if the userinfo endpoint cannot be reached
      */
     public function fetchUserinfo(Tokens $tokens): Userinfo
     {

--- a/src/Client/AuthorizationCode.php
+++ b/src/Client/AuthorizationCode.php
@@ -11,6 +11,7 @@ use DigitalCz\OpenIDConnect\Exception\NetworkException;
 use DigitalCz\OpenIDConnect\Util\Pkce;
 use InvalidArgumentException;
 use RuntimeException;
+use Symfony\Contracts\HttpClient\Exception\ExceptionInterface as HttpClientExceptionInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 /**
@@ -190,8 +191,12 @@ final readonly class AuthorizationCode
 
         $options = ['auth_bearer' => (string)$accessToken];
 
-        /** @var array<string, mixed> $response */
-        $response = $this->httpClient->request('GET', $userinfoEndpoint, $options)->toArray();
+        try {
+            /** @var array<string, mixed> $response */
+            $response = $this->httpClient->request('GET', $userinfoEndpoint, $options)->toArray();
+        } catch (HttpClientExceptionInterface $e) {
+            throw new NetworkException('Userinfo request failed: ' . $e->getMessage(), 0, $e);
+        }
 
         $userinfo = new Userinfo($response);
 

--- a/src/Client/ClientCredentials.php
+++ b/src/Client/ClientCredentials.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace DigitalCz\OpenIDConnect\Client;
 
 use DigitalCz\OpenIDConnect\Config\Config;
+use DigitalCz\OpenIDConnect\Exception\DiscoveryException;
+use DigitalCz\OpenIDConnect\Exception\NetworkException;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 /**
@@ -29,6 +31,9 @@ final readonly class ClientCredentials
      *
      * @param array<string, string> $params Additional body parameters
      * @return Tokens Access token for API access
+     *
+     * @throws DiscoveryException if provider metadata cannot be resolved
+     * @throws NetworkException if the token endpoint cannot be reached
      */
     public function fetchTokens(array $params = []): Tokens
     {

--- a/src/Client/DeviceAuthorization.php
+++ b/src/Client/DeviceAuthorization.php
@@ -15,6 +15,7 @@ use DigitalCz\OpenIDConnect\Exception\NetworkException;
 use DigitalCz\OpenIDConnect\Exception\SlowDownException;
 use DigitalCz\OpenIDConnect\Util\SimpleClock;
 use Psr\Clock\ClockInterface;
+use Symfony\Contracts\HttpClient\Exception\ExceptionInterface as HttpClientExceptionInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 /**
@@ -68,8 +69,12 @@ final readonly class DeviceAuthorization
         $authenticator = new ClientAuthenticator($clientMetadata, $issuerMetadata);
         $options = $authenticator->applyAuthentication($options);
 
-        /** @var array<string, mixed> $data */
-        $data = $this->httpClient->request('POST', $url, $options)->toArray();
+        try {
+            /** @var array<string, mixed> $data */
+            $data = $this->httpClient->request('POST', $url, $options)->toArray();
+        } catch (HttpClientExceptionInterface $e) {
+            throw new NetworkException('Device authorization request failed: ' . $e->getMessage(), 0, $e);
+        }
 
         return DeviceAuthorizationResponse::fromResponse($data);
     }
@@ -104,10 +109,12 @@ final readonly class DeviceAuthorization
         $authenticator = new ClientAuthenticator($clientMetadata, $issuerMetadata);
         $options = $authenticator->applyAuthentication($options);
 
-        $response = $this->httpClient->request('POST', $url, $options);
-
-        /** @var array<string, mixed> $data */
-        $data = $response->toArray(false);
+        try {
+            /** @var array<string, mixed> $data */
+            $data = $this->httpClient->request('POST', $url, $options)->toArray(false);
+        } catch (HttpClientExceptionInterface $e) {
+            throw new NetworkException('Device token request failed: ' . $e->getMessage(), 0, $e);
+        }
 
         if (isset($data['error']) && is_string($data['error'])) {
             throw $this->mapError($data['error'], $data);

--- a/src/Client/DeviceAuthorization.php
+++ b/src/Client/DeviceAuthorization.php
@@ -10,6 +10,8 @@ use DigitalCz\OpenIDConnect\Exception\DeviceAuthorizationDeniedException;
 use DigitalCz\OpenIDConnect\Exception\DeviceAuthorizationException;
 use DigitalCz\OpenIDConnect\Exception\DeviceAuthorizationExpiredException;
 use DigitalCz\OpenIDConnect\Exception\DeviceAuthorizationPendingException;
+use DigitalCz\OpenIDConnect\Exception\DiscoveryException;
+use DigitalCz\OpenIDConnect\Exception\NetworkException;
 use DigitalCz\OpenIDConnect\Exception\SlowDownException;
 use DigitalCz\OpenIDConnect\Util\SimpleClock;
 use Psr\Clock\ClockInterface;
@@ -49,6 +51,9 @@ final readonly class DeviceAuthorization
      * Request a device and user code from the authorization server.
      *
      * @param array<string, string> $params Additional body parameters (e.g. audience)
+     *
+     * @throws DiscoveryException if provider metadata cannot be resolved
+     * @throws NetworkException if the device authorization endpoint cannot be reached
      */
     public function requestDeviceAuthorization(array $params = []): DeviceAuthorizationResponse
     {
@@ -81,6 +86,8 @@ final readonly class DeviceAuthorization
      * @throws DeviceAuthorizationException         Any other OAuth error.
      * @throws DeviceAuthorizationExpiredException  Device code expired.
      * @throws DeviceAuthorizationPendingException  User has not yet authorized.
+     * @throws DiscoveryException                   Provider metadata cannot be resolved.
+     * @throws NetworkException                     Token endpoint cannot be reached.
      * @throws SlowDownException                    Polling too fast - increase interval.
      */
     public function fetchTokens(string $deviceCode, array $params = []): Tokens
@@ -119,6 +126,12 @@ final readonly class DeviceAuthorization
      * elapses.
      *
      * @param array<string, string> $params Additional body parameters forwarded to each poll
+     *
+     * @throws DeviceAuthorizationDeniedException   User denied the request.
+     * @throws DeviceAuthorizationException         Any other non-recoverable OAuth error.
+     * @throws DeviceAuthorizationExpiredException  Device code expired before authorization completed.
+     * @throws DiscoveryException                   Provider metadata cannot be resolved.
+     * @throws NetworkException                     Token endpoint cannot be reached.
      */
     public function pollForTokens(DeviceAuthorizationResponse $response, array $params = []): Tokens
     {

--- a/src/Client/JwtIdTokenValidator.php
+++ b/src/Client/JwtIdTokenValidator.php
@@ -6,7 +6,9 @@ namespace DigitalCz\OpenIDConnect\Client;
 
 use DigitalCz\OpenIDConnect\Config\Config;
 use DigitalCz\OpenIDConnect\Discovery\JwksLoader;
+use DigitalCz\OpenIDConnect\Exception\DiscoveryException;
 use DigitalCz\OpenIDConnect\Exception\InvalidTokenException;
+use DigitalCz\OpenIDConnect\Exception\NetworkException;
 use DigitalCz\OpenIDConnect\Util\SignatureAlgorithmsFactory;
 use DigitalCz\OpenIDConnect\Util\SimpleClock;
 use Exception;
@@ -80,6 +82,10 @@ final class JwtIdTokenValidator implements IdTokenValidator
         $jwsLoader->loadAndVerifyWithKeySet((string)$token, $jwkSet, $signature);
     }
 
+    /**
+     * @throws DiscoveryException if provider metadata cannot be resolved
+     * @throws NetworkException if the discovery endpoint cannot be reached
+     */
     private function createJwsLoader(): JWSLoader
     {
         $idTokenSigningAlgorithms = $this->config->issuerMetadata()->idTokenSigningAlgValuesSupported();
@@ -92,11 +98,19 @@ final class JwtIdTokenValidator implements IdTokenValidator
         );
     }
 
+    /**
+     * @throws DiscoveryException if provider metadata cannot be resolved
+     * @throws NetworkException if the discovery endpoint cannot be reached
+     */
     private function validateClaims(IdToken $token): void
     {
         $this->createClaimCheckerManager()->check($token->claims(), $this->mandatoryClaims);
     }
 
+    /**
+     * @throws DiscoveryException if provider metadata cannot be resolved
+     * @throws NetworkException if the discovery endpoint cannot be reached
+     */
     private function createClaimCheckerManager(): ClaimCheckerManager
     {
         return $this->claimCheckerManager ??= new ClaimCheckerManager([
@@ -139,6 +153,9 @@ final class JwtIdTokenValidator implements IdTokenValidator
         }
     }
 
+    /**
+     * @throws InvalidTokenException if the nonce does not match
+     */
     private function validateNonce(IdToken $token, ?string $nonce): void
     {
         if ($nonce === null) {

--- a/src/Client/RequestTokensTrait.php
+++ b/src/Client/RequestTokensTrait.php
@@ -6,6 +6,7 @@ namespace DigitalCz\OpenIDConnect\Client;
 
 use DigitalCz\OpenIDConnect\Exception\DiscoveryException;
 use DigitalCz\OpenIDConnect\Exception\NetworkException;
+use Symfony\Contracts\HttpClient\Exception\ExceptionInterface as HttpClientExceptionInterface;
 
 trait RequestTokensTrait
 {
@@ -29,8 +30,12 @@ trait RequestTokensTrait
         $authenticator = new ClientAuthenticator($clientMetadata, $issuerMetadata);
         $options = $authenticator->applyAuthentication($options);
 
-        $response = $this->httpClient->request('POST', $url, $options);
+        try {
+            $data = $this->httpClient->request('POST', $url, $options)->toArray();
+        } catch (HttpClientExceptionInterface $e) {
+            throw new NetworkException('Token request failed: ' . $e->getMessage(), 0, $e);
+        }
 
-        return Tokens::fromTokenResponse($response->toArray());
+        return Tokens::fromTokenResponse($data);
     }
 }

--- a/src/Client/RequestTokensTrait.php
+++ b/src/Client/RequestTokensTrait.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace DigitalCz\OpenIDConnect\Client;
 
+use DigitalCz\OpenIDConnect\Exception\DiscoveryException;
+use DigitalCz\OpenIDConnect\Exception\NetworkException;
+
 trait RequestTokensTrait
 {
     /**
@@ -11,6 +14,9 @@ trait RequestTokensTrait
      *
      * @param array<string, string|null> $params Request body parameters
      * @return Tokens Created tokens
+     *
+     * @throws DiscoveryException if provider metadata cannot be resolved
+     * @throws NetworkException if the token endpoint cannot be reached
      */
     private function requestTokens(array $params): Tokens
     {

--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -4,11 +4,20 @@ declare(strict_types=1);
 
 namespace DigitalCz\OpenIDConnect\Config;
 
+use DigitalCz\OpenIDConnect\Exception\DiscoveryException;
+use DigitalCz\OpenIDConnect\Exception\NetworkException;
+
 /**
  * Main configuration interface
  */
 interface Config
 {
+    /**
+     * Provider metadata, resolved via discovery for {@see DiscoveryConfig}.
+     *
+     * @throws DiscoveryException if the discovery document cannot be fetched or is invalid
+     * @throws NetworkException if the discovery endpoint cannot be reached
+     */
     public function issuerMetadata(): IssuerMetadata;
 
     public function clientMetadata(): ClientMetadata;

--- a/src/Discovery/Discoverer.php
+++ b/src/Discovery/Discoverer.php
@@ -5,12 +5,19 @@ declare(strict_types=1);
 namespace DigitalCz\OpenIDConnect\Discovery;
 
 use DigitalCz\OpenIDConnect\Config\IssuerMetadata;
+use DigitalCz\OpenIDConnect\Exception\DiscoveryException;
+use DigitalCz\OpenIDConnect\Exception\NetworkException;
 
 /**
  * Interface for OIDC discovery implementations.
  */
 interface Discoverer
 {
-    /** Discovers OIDC provider metadata from issuer. */
+    /**
+     * Discovers OIDC provider metadata from issuer.
+     *
+     * @throws DiscoveryException if the discovery document cannot be fetched or is invalid
+     * @throws NetworkException if the discovery endpoint cannot be reached
+     */
     public function discover(string $issuer): IssuerMetadata;
 }

--- a/src/Discovery/JwksLoader.php
+++ b/src/Discovery/JwksLoader.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace DigitalCz\OpenIDConnect\Discovery;
 
+use DigitalCz\OpenIDConnect\Exception\DiscoveryException;
+use DigitalCz\OpenIDConnect\Exception\NetworkException;
+
 /**
  * Interface for JWKS loading.
  */
@@ -13,6 +16,9 @@ interface JwksLoader
      * Loads JWKS from URI.
      *
      * @return mixed[]
+     *
+     * @throws DiscoveryException if the JWKS document cannot be fetched or is invalid
+     * @throws NetworkException if the JWKS endpoint cannot be reached
      */
     public function load(string $jwksUri): array;
 }

--- a/src/ResourceServer/AccessTokenValidator.php
+++ b/src/ResourceServer/AccessTokenValidator.php
@@ -4,6 +4,11 @@ declare(strict_types=1);
 
 namespace DigitalCz\OpenIDConnect\ResourceServer;
 
+use DigitalCz\OpenIDConnect\Exception\DiscoveryException;
+use DigitalCz\OpenIDConnect\Exception\IntrospectionException;
+use DigitalCz\OpenIDConnect\Exception\InvalidTokenException;
+use DigitalCz\OpenIDConnect\Exception\NetworkException;
+
 /**
  * Validation strategy interface
  */
@@ -16,6 +21,11 @@ interface AccessTokenValidator
 
     /**
      * Validate access token
+     *
+     * @throws DiscoveryException if provider metadata cannot be resolved
+     * @throws IntrospectionException if the introspection endpoint request fails (opaque tokens)
+     * @throws InvalidTokenException if the token is malformed, unsupported, or fails validation
+     * @throws NetworkException if a required endpoint cannot be reached
      */
     public function validate(AccessToken $token): ValidatedAccessToken;
 }

--- a/src/ResourceServer/JwtAccessTokenValidator.php
+++ b/src/ResourceServer/JwtAccessTokenValidator.php
@@ -6,7 +6,9 @@ namespace DigitalCz\OpenIDConnect\ResourceServer;
 
 use DigitalCz\OpenIDConnect\Config\Config;
 use DigitalCz\OpenIDConnect\Discovery\JwksLoader;
+use DigitalCz\OpenIDConnect\Exception\DiscoveryException;
 use DigitalCz\OpenIDConnect\Exception\InvalidTokenException;
+use DigitalCz\OpenIDConnect\Exception\NetworkException;
 use DigitalCz\OpenIDConnect\Util\SignatureAlgorithmsFactory;
 use DigitalCz\OpenIDConnect\Util\SimpleClock;
 use Jose\Component\Checker\AlgorithmChecker;
@@ -80,6 +82,10 @@ final class JwtAccessTokenValidator implements AccessTokenValidator
         }
     }
 
+    /**
+     * @throws DiscoveryException if provider metadata cannot be resolved
+     * @throws NetworkException if the JWKS endpoint cannot be reached
+     */
     private function validateSignature(AccessToken $token): JWS
     {
         $jwksUri = $this->config->issuerMetadata()->jwksUri();
@@ -98,6 +104,8 @@ final class JwtAccessTokenValidator implements AccessTokenValidator
      * present and equal to the expected type; per RFC 9068 both the bare form
      * ("at+jwt") and the prefixed media type ("application/at+jwt") are accepted.
      * The comparison is case-insensitive, as media types are (RFC 9068 / RFC 2045).
+     *
+     * @throws InvalidTokenException if the typ header is missing or does not match
      */
     private function validateTokenType(JWS $jws): void
     {
@@ -121,6 +129,10 @@ final class JwtAccessTokenValidator implements AccessTokenValidator
         }
     }
 
+    /**
+     * @throws DiscoveryException if provider metadata cannot be resolved
+     * @throws NetworkException if the discovery endpoint cannot be reached
+     */
     private function createJwsLoader(): JWSLoader
     {
         $idTokenSigningAlgorithms = $this->config->issuerMetadata()->idTokenSigningAlgValuesSupported();
@@ -135,12 +147,19 @@ final class JwtAccessTokenValidator implements AccessTokenValidator
 
     /**
      * @param array<string, mixed> $claims
+     *
+     * @throws DiscoveryException if provider metadata cannot be resolved
+     * @throws NetworkException if the discovery endpoint cannot be reached
      */
     private function validateClaims(array $claims): void
     {
         $this->createClaimCheckerManager()->check($claims, $this->mandatoryClaims);
     }
 
+    /**
+     * @throws DiscoveryException if provider metadata cannot be resolved
+     * @throws NetworkException if the discovery endpoint cannot be reached
+     */
     private function createClaimCheckerManager(): ClaimCheckerManager
     {
         return $this->claimCheckerManager ??= new ClaimCheckerManager([

--- a/src/ResourceServer/ResourceServer.php
+++ b/src/ResourceServer/ResourceServer.php
@@ -5,6 +5,10 @@ declare(strict_types=1);
 namespace DigitalCz\OpenIDConnect\ResourceServer;
 
 use DigitalCz\OpenIDConnect\Exception\ConfigurationException;
+use DigitalCz\OpenIDConnect\Exception\DiscoveryException;
+use DigitalCz\OpenIDConnect\Exception\IntrospectionException;
+use DigitalCz\OpenIDConnect\Exception\InvalidTokenException;
+use DigitalCz\OpenIDConnect\Exception\NetworkException;
 
 /**
  * Token validation orchestrator
@@ -20,12 +24,21 @@ final readonly class ResourceServer
 
     /**
      * Validate access token using appropriate validator
+     *
+     * @throws ConfigurationException if no configured validator supports the token type
+     * @throws DiscoveryException if provider metadata cannot be resolved
+     * @throws IntrospectionException if the introspection endpoint request fails (opaque tokens)
+     * @throws InvalidTokenException if the token is malformed, unsupported, or fails validation
+     * @throws NetworkException if a required endpoint cannot be reached
      */
     public function introspect(AccessToken $token): ValidatedAccessToken
     {
         return $this->getValidator($token)->validate($token);
     }
 
+    /**
+     * @throws ConfigurationException if no configured validator supports the token type
+     */
     private function getValidator(AccessToken $token): AccessTokenValidator
     {
         foreach ($this->validators as $validator) {

--- a/src/Util/SecureHttpClient.php
+++ b/src/Util/SecureHttpClient.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace DigitalCz\OpenIDConnect\Util;
 
+use DigitalCz\OpenIDConnect\Exception\DiscoveryException;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 use Symfony\Contracts\HttpClient\ResponseStreamInterface;
@@ -23,6 +24,8 @@ final class SecureHttpClient implements HttpClientInterface
 
     /**
      * @param array<string, mixed> $options
+     *
+     * @throws DiscoveryException if the URL is not transport-secure (non-HTTPS, non-loopback)
      */
     public function request(string $method, string $url, array $options = []): ResponseInterface
     {

--- a/src/Util/SecureHttpClient.php
+++ b/src/Util/SecureHttpClient.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace DigitalCz\OpenIDConnect\Util;
 
 use DigitalCz\OpenIDConnect\Exception\DiscoveryException;
+use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 use Symfony\Contracts\HttpClient\ResponseStreamInterface;
@@ -26,6 +27,7 @@ final class SecureHttpClient implements HttpClientInterface
      * @param array<string, mixed> $options
      *
      * @throws DiscoveryException if the URL is not transport-secure (non-HTTPS, non-loopback)
+     * @throws TransportExceptionInterface when an unsupported option is passed
      */
     public function request(string $method, string $url, array $options = []): ResponseInterface
     {

--- a/tests/Client/AuthorizationCodeTest.php
+++ b/tests/Client/AuthorizationCodeTest.php
@@ -7,6 +7,7 @@ namespace DigitalCz\OpenIDConnect\Client;
 use DigitalCz\OpenIDConnect\Config\ClientMetadata;
 use DigitalCz\OpenIDConnect\Config\Config;
 use DigitalCz\OpenIDConnect\Config\IssuerMetadata;
+use DigitalCz\OpenIDConnect\Exception\NetworkException;
 use DigitalCz\OpenIDConnect\TestCase;
 use DigitalCz\OpenIDConnect\Util\PkceMethod;
 use InvalidArgumentException;
@@ -14,6 +15,8 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use RuntimeException;
+use Symfony\Contracts\HttpClient\Exception\ClientExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 
@@ -204,6 +207,19 @@ class AuthorizationCodeTest extends TestCase
         $this->authorizationCode->fetchTokens($authorizationCode);
     }
 
+    public function testFetchTokensWrapsHttpClientExceptionInNetworkException(): void
+    {
+        $response = $this->createMock(ResponseInterface::class);
+        $response->method('toArray')->willThrowException($this->createMock(ClientExceptionInterface::class));
+
+        $this->httpClient->method('request')->willReturn($response);
+
+        $this->expectException(NetworkException::class);
+        $this->expectExceptionMessage('Token request failed:');
+
+        $this->authorizationCode->fetchTokens('test-auth-code');
+    }
+
     public function testRefreshTokenSuccess(): void
     {
         $originalTokens = $this->createTokensWithRefreshToken();
@@ -301,6 +317,21 @@ class AuthorizationCodeTest extends TestCase
 
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Userinfo sub does not match id_token sub');
+
+        $this->authorizationCode->fetchUserinfo($tokens);
+    }
+
+    public function testFetchUserinfoWrapsHttpClientExceptionInNetworkException(): void
+    {
+        $tokens = $this->createTokensWithIdToken();
+
+        $response = $this->createMock(ResponseInterface::class);
+        $response->method('toArray')->willThrowException($this->createMock(TransportExceptionInterface::class));
+
+        $this->httpClient->method('request')->willReturn($response);
+
+        $this->expectException(NetworkException::class);
+        $this->expectExceptionMessage('Userinfo request failed:');
 
         $this->authorizationCode->fetchUserinfo($tokens);
     }

--- a/tests/Client/DeviceAuthorizationTest.php
+++ b/tests/Client/DeviceAuthorizationTest.php
@@ -12,11 +12,14 @@ use DigitalCz\OpenIDConnect\Exception\DeviceAuthorizationDeniedException;
 use DigitalCz\OpenIDConnect\Exception\DeviceAuthorizationException;
 use DigitalCz\OpenIDConnect\Exception\DeviceAuthorizationExpiredException;
 use DigitalCz\OpenIDConnect\Exception\DeviceAuthorizationPendingException;
+use DigitalCz\OpenIDConnect\Exception\NetworkException;
 use DigitalCz\OpenIDConnect\Exception\SlowDownException;
 use DigitalCz\OpenIDConnect\TestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Clock\ClockInterface;
+use Symfony\Contracts\HttpClient\Exception\ServerExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 use UnexpectedValueException;
@@ -174,6 +177,32 @@ class DeviceAuthorizationTest extends TestCase
         $this->expectExceptionMessage('expires_in');
 
         $this->deviceAuthorization->requestDeviceAuthorization();
+    }
+
+    public function testRequestDeviceAuthorizationWrapsHttpClientExceptionInNetworkException(): void
+    {
+        $response = $this->createMock(ResponseInterface::class);
+        $response->method('toArray')->willThrowException($this->createMock(ServerExceptionInterface::class));
+
+        $this->httpClient->method('request')->willReturn($response);
+
+        $this->expectException(NetworkException::class);
+        $this->expectExceptionMessage('Device authorization request failed:');
+
+        $this->deviceAuthorization->requestDeviceAuthorization();
+    }
+
+    public function testFetchTokensWrapsHttpClientExceptionInNetworkException(): void
+    {
+        $response = $this->createMock(ResponseInterface::class);
+        $response->method('toArray')->willThrowException($this->createMock(TransportExceptionInterface::class));
+
+        $this->httpClient->method('request')->willReturn($response);
+
+        $this->expectException(NetworkException::class);
+        $this->expectExceptionMessage('Device token request failed:');
+
+        $this->deviceAuthorization->fetchTokens('device-code');
     }
 
     public function testFetchTokensSuccess(): void


### PR DESCRIPTION
## What

Makes it impossible to forget a `@throws` for any checked exception, fixes every resulting gap, and makes the library's exception contract uniform (callers only ever catch the `DigitalCz\OpenIDConnect\Exception\*` family).

### a) PHPStan config

Enables checked-exception analysis. Two interfaces are marked checked:

```neon
exceptions:
    check:
        missingCheckedExceptionInThrows: true   # can't forget a @throws
        tooWideThrowType: true                  # can't declare one that's never thrown
    checkedExceptionClasses:
        - DigitalCz\OpenIDConnect\Exception\Exception          # all of our own exceptions
        - Symfony\Contracts\HttpClient\Exception\ExceptionInterface
```

The `Exception` marker makes every domain exception checked. Marking Symfony's HTTP-client `ExceptionInterface` checked is the enforcement mechanism that **forces** every call site to either handle those exceptions or declare them — so a raw Symfony exception can never silently leak out of the public API, now or in future code.

### b) Fixed all `@throws` gaps

Annotated the **interface contracts** so checked exceptions propagate through interface-typed calls:

- `Config::issuerMetadata()`, `Discoverer::discover()`, `JwksLoader::load()` → `DiscoveryException` / `NetworkException`
- `AccessTokenValidator::validate()` → `InvalidTokenException`, `IntrospectionException`, `DiscoveryException`, `NetworkException`

Concrete `validate()` implementations and caching decorators inherit their interface contract; the `try/catch (Throwable)` blocks in the validators narrow the public surface back to `InvalidTokenException`.

### c) Wrap Symfony HTTP exceptions (uniform contract)

The token / userinfo / device-authorization flows called `->toArray()` and let raw Symfony exceptions escape, while discovery/JWKS/introspection already wrapped them. With Symfony's `ExceptionInterface` now checked, PHPStan flagged exactly those leak sites; each is now wrapped into `NetworkException`:

- `RequestTokensTrait::requestTokens()` (auth-code + client-credentials)
- `AuthorizationCode::fetchUserinfo()`
- `DeviceAuthorization::requestDeviceAuthorization()` and `fetchTokens()`

This also makes the `@throws NetworkException … endpoint cannot be reached` descriptions accurate (addresses the Copilot review feedback). New tests assert Symfony HTTP failures surface as `NetworkException`.

## Follow-up (not in this PR)

The auth-code/client-credentials token endpoint uses `->toArray()` (throw on 4xx), so an OAuth **400** error is wrapped as `NetworkException` rather than parsed for `error`/`error_description` (the original exception is preserved via `getPrevious()`). First-class OAuth token-error parsing — like the device flow already does via `toArray(false)` + `mapError()` — would be a natural follow-up and likely warrants a dedicated exception type.

## Design note for review

`ConfigurationException` extends `LogicException` but implements the `Exception` marker, so it's treated as **checked** (e.g. `ResourceServer::introspect()` declares it). If you'd prefer logic/programming-error exceptions to stay unchecked, add it to `uncheckedExceptionClasses` and drop that one `@throws`.

## Checks

`composer checks` is green: `phpcs`, `phpstan` ("No errors"), and `phpunit` (593 tests, exit 0). Runtime changes are limited to the four wrap sites; the rest is PHPDoc + config + tests.

Co-Authored-By: Claude Code

https://claude.ai/code/session_01SgciNQuunWzE5sKKVYGCQs