### PR TITLE
feat: configurable resource-server audience validation (#93)

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,44 @@ $oidc = OidcFactory::create(
 When set, the `typ` header must be present and equal to the expected value; both `at+jwt` and `application/at+jwt`
 are accepted. It is disabled by default because not all authorization servers emit the `typ` header.
 
+#### Audience validation
+
+By default the resource server accepts only tokens whose `aud` claim matches the `clientId`. Use
+`resourceServerAudience` to decouple the accepted audience from the client id — for example when the resource
+server has several identities of its own, or when it must accept tokens minted for other first-party services:
+
+```php
+// Accept a token whose "aud" matches any of the listed audiences.
+$oidc = OidcFactory::create(
+    httpClient: $httpClient,
+    issuer: 'https://issuer.example.com',
+    clientId: 'my-client',
+    resourceServerAudience: ['service-a', 'service-b'],
+);
+
+// Disable the audience check entirely (validate signature + issuer + expiry only).
+$oidc = OidcFactory::create(
+    httpClient: $httpClient,
+    issuer: 'https://issuer.example.com',
+    clientId: 'my-client',
+    resourceServerAudience: null,
+);
+```
+
+Passing a **list** verifies that the token's `aud` (a single value or an array) intersects the configured
+audiences — this is the standard model for a resource server with multiple identities (RFC 9068 §4).
+
+Passing **`null`** turns the audience check off. This is a **deliberate deviation from RFC 9068**, which requires
+rejecting a token whose `aud` does not identify the resource server. It exists for closed first-party token
+propagation across services sharing one issuer; the standards-correct alternative is
+[Token Exchange (RFC 8693)](https://www.rfc-editor.org/rfc/rfc8693). The presence of the `aud` claim itself is
+still governed by the validator's mandatory-claims set. Leaving `resourceServerAudience` unset keeps the default
+(`aud` must equal `clientId`).
+
+When wiring `JwtAccessTokenValidator` manually, the same `string|list<string>|null` values apply to its `$audience`
+argument. For fully custom validation you can inject a replacement set of claim checkers via `$claimCheckers`, which
+then supersedes the default issuer/audience/expiry/issued-at/not-before checkers.
+
 ### Back-Channel Logout
 
 Implements [OpenID Connect Back-Channel Logout 1.0](https://openid.net/specs/openid-connect-backchannel-1_0.html).

--- a/README.md
+++ b/README.md
@@ -240,7 +240,8 @@ are accepted. It is disabled by default because not all authorization servers em
 
 #### Audience validation
 
-By default the resource server accepts only tokens whose `aud` claim matches the `clientId`. Use
+By default the resource server's JWT access-token validator accepts only tokens whose `aud` claim matches the
+`clientId` (opaque tokens are unaffected — they're validated via introspection, which only checks `active`). Use
 `resourceServerAudience` to decouple the accepted audience from the client id — for example when the resource
 server has several identities of its own, or when it must accept tokens minted for other first-party services:
 
@@ -253,7 +254,8 @@ $oidc = OidcFactory::create(
     resourceServerAudience: ['service-a', 'service-b'],
 );
 
-// Disable the audience check entirely (validate signature + issuer + expiry only).
+// Disable the audience check entirely (the "aud" value is no longer verified against anything;
+// its presence is still required by the default mandatory-claims set).
 $oidc = OidcFactory::create(
     httpClient: $httpClient,
     issuer: 'https://issuer.example.com',

--- a/examples/manual_config.php
+++ b/examples/manual_config.php
@@ -66,7 +66,9 @@ $clientCredentials = new ClientCredentials($config, $httpClient);
 // Create device authorization flow handler
 $deviceAuthorization = new DeviceAuthorization($config, $httpClient);
 
-// Create access token validators for resource server
+// Create access token validators for resource server.
+// The third argument is the expected audience: a string, a list of accepted audiences
+// (e.g. ['service-a', 'service-b']), or null to disable the audience check entirely.
 $jwtAccessTokenValidator = new JwtAccessTokenValidator(
     $config,
     $jwksLoader,

--- a/src/OidcFactory.php
+++ b/src/OidcFactory.php
@@ -39,6 +39,9 @@ final readonly class OidcFactory
     /**
      * @param string|array<string, string|string[]|bool>|IssuerMetadata $issuer
      * @param string|list<string> $defaultScopes
+     * @param string|list<string>|false|null $resourceServerAudience Expected audience for resource-server JWT
+     *        access-token validation. false (default) uses the client id; a string or list configures the accepted
+     *        audience(s); null disables the audience check (deviates from RFC 9068 — see JwtAccessTokenValidator).
      */
     public static function create(
         HttpClientInterface $httpClient,
@@ -59,6 +62,7 @@ final readonly class OidcFactory
         ?string $accessTokenType = null,
         ?string $backchannelLogoutUri = null,
         bool $backchannelLogoutSessionRequired = false,
+        string|array|false|null $resourceServerAudience = false,
     ): Oidc {
         if (is_string($defaultScopes)) {
             $defaultScopes = explode(' ', $defaultScopes);
@@ -133,7 +137,7 @@ final readonly class OidcFactory
         $jwtAccessTokenValidator = new JwtAccessTokenValidator(
             $config,
             $jwksLoader,
-            $clientMetadata->clientId(),
+            $resourceServerAudience === false ? $clientMetadata->clientId() : $resourceServerAudience,
             $clock,
             expectedTokenType: $accessTokenType,
         );

--- a/src/ResourceServer/JwtAccessTokenValidator.php
+++ b/src/ResourceServer/JwtAccessTokenValidator.php
@@ -88,6 +88,12 @@ final class JwtAccessTokenValidator implements AccessTokenValidator
             $seenClaims = [];
 
             foreach ($this->claimCheckers as $claimChecker) {
+                if (!$claimChecker instanceof ClaimChecker) {
+                    throw new InvalidArgumentException(
+                        sprintf('Each element of $claimCheckers must implement %s.', ClaimChecker::class),
+                    );
+                }
+
                 $claim = $claimChecker->supportedClaim();
 
                 if (isset($seenClaims[$claim])) {

--- a/src/ResourceServer/JwtAccessTokenValidator.php
+++ b/src/ResourceServer/JwtAccessTokenValidator.php
@@ -88,13 +88,6 @@ final class JwtAccessTokenValidator implements AccessTokenValidator
             $seenClaims = [];
 
             foreach ($this->claimCheckers as $claimChecker) {
-                // @phpstan-ignore instanceof.alwaysTrue (runtime guard; PHP arrays don't enforce the docblock's element type)
-                if (!$claimChecker instanceof ClaimChecker) {
-                    throw new InvalidArgumentException(
-                        sprintf('Each element of $claimCheckers must implement %s.', ClaimChecker::class),
-                    );
-                }
-
                 $claim = $claimChecker->supportedClaim();
 
                 if (isset($seenClaims[$claim])) {

--- a/src/ResourceServer/JwtAccessTokenValidator.php
+++ b/src/ResourceServer/JwtAccessTokenValidator.php
@@ -13,6 +13,8 @@ use DigitalCz\OpenIDConnect\Util\SignatureAlgorithmsFactory;
 use DigitalCz\OpenIDConnect\Util\SimpleClock;
 use Jose\Component\Checker\AlgorithmChecker;
 use Jose\Component\Checker\AudienceChecker;
+use Jose\Component\Checker\CallableChecker;
+use Jose\Component\Checker\ClaimChecker;
 use Jose\Component\Checker\ClaimCheckerManager;
 use Jose\Component\Checker\ExpirationTimeChecker;
 use Jose\Component\Checker\HeaderCheckerManager;
@@ -39,16 +41,27 @@ final class JwtAccessTokenValidator implements AccessTokenValidator
     private ?JWSLoader $jwsLoader = null;
 
     /**
+     * @param string|list<string>|null $audience Expected token audience. A string matches a single audience
+     *                                            (RFC 9068 §4); a list accepts a token whose "aud" matches any
+     *                                            of the given values (a resource server with multiple identities);
+     *                                            null skips audience validation entirely. Skipping is a deliberate
+     *                                            deviation from RFC 9068 — the standards-correct way to accept a
+     *                                            token issued for another audience is token exchange (RFC 8693).
+     *                                            The presence of the "aud" claim is still governed by $mandatoryClaims.
      * @param list<string> $mandatoryClaims
+     * @param list<ClaimChecker>|null $claimCheckers When provided, fully replaces the default claim checker set
+     *                                               (issuer, audience, expiration, issued-at, not-before); $audience
+     *                                               is then ignored. Escape hatch for fully custom validation.
      */
     public function __construct(
         private readonly Config $config,
         private readonly JwksLoader $jwksLoader,
-        private readonly string $audience,
+        private readonly string|array|null $audience,
         private readonly ClockInterface $clock = new SimpleClock(),
         private readonly int $allowedTimeDrift = 10,
         private readonly array $mandatoryClaims = ['iss', 'sub', 'aud', 'exp', 'iat'],
         private readonly ?string $expectedTokenType = null,
+        private readonly ?array $claimCheckers = null,
     ) {
     }
 
@@ -164,12 +177,63 @@ final class JwtAccessTokenValidator implements AccessTokenValidator
      */
     private function createClaimCheckerManager(): ClaimCheckerManager
     {
-        return $this->claimCheckerManager ??= new ClaimCheckerManager([
+        if ($this->claimCheckerManager !== null) {
+            return $this->claimCheckerManager;
+        }
+
+        if ($this->claimCheckers !== null) {
+            return $this->claimCheckerManager = new ClaimCheckerManager($this->claimCheckers);
+        }
+
+        $checkers = [
             new IssuerChecker([$this->config->issuerMetadata()->issuer()]),
-            new AudienceChecker($this->audience),
             new ExpirationTimeChecker($this->clock, $this->allowedTimeDrift),
             new IssuedAtChecker($this->clock, $this->allowedTimeDrift),
             new NotBeforeChecker($this->clock, $this->allowedTimeDrift),
-        ]);
+        ];
+
+        $audienceChecker = $this->createAudienceChecker();
+
+        if ($audienceChecker !== null) {
+            $checkers[] = $audienceChecker;
+        }
+
+        return $this->claimCheckerManager = new ClaimCheckerManager($checkers);
+    }
+
+    /**
+     * Build the "aud" claim checker for the configured audience.
+     *
+     * A single string uses web-token's {@see AudienceChecker}. A list accepts a token whose "aud"
+     * matches any of the configured values (string aud must be one of them; array aud must intersect
+     * them). Null disables the audience check.
+     */
+    private function createAudienceChecker(): ?ClaimChecker
+    {
+        if ($this->audience === null) {
+            return null;
+        }
+
+        if (is_string($this->audience)) {
+            return new AudienceChecker($this->audience);
+        }
+
+        $accepted = $this->audience;
+
+        return new CallableChecker('aud', static function (mixed $aud) use ($accepted): bool {
+            if (is_string($aud)) {
+                return in_array($aud, $accepted, true);
+            }
+
+            if (is_array($aud)) {
+                foreach ($aud as $value) {
+                    if (is_string($value) && in_array($value, $accepted, true)) {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        });
     }
 }

--- a/src/ResourceServer/JwtAccessTokenValidator.php
+++ b/src/ResourceServer/JwtAccessTokenValidator.php
@@ -11,6 +11,7 @@ use DigitalCz\OpenIDConnect\Exception\InvalidTokenException;
 use DigitalCz\OpenIDConnect\Exception\NetworkException;
 use DigitalCz\OpenIDConnect\Util\SignatureAlgorithmsFactory;
 use DigitalCz\OpenIDConnect\Util\SimpleClock;
+use InvalidArgumentException;
 use Jose\Component\Checker\AlgorithmChecker;
 use Jose\Component\Checker\AudienceChecker;
 use Jose\Component\Checker\CallableChecker;
@@ -48,10 +49,12 @@ final class JwtAccessTokenValidator implements AccessTokenValidator
      *                                            deviation from RFC 9068 — the standards-correct way to accept a
      *                                            token issued for another audience is token exchange (RFC 8693).
      *                                            The presence of the "aud" claim is still governed by $mandatoryClaims.
+     *                                            Must be null when $claimCheckers is provided.
      * @param list<string> $mandatoryClaims
      * @param list<ClaimChecker>|null $claimCheckers When provided, fully replaces the default claim checker set
-     *                                               (issuer, audience, expiration, issued-at, not-before); $audience
-     *                                               is then ignored. Escape hatch for fully custom validation.
+     *                                               (issuer, audience, expiration, issued-at, not-before). Must be
+     *                                               non-empty, each checker covering a distinct claim, and $audience
+     *                                               must be null. Escape hatch for fully custom validation.
      */
     public function __construct(
         private readonly Config $config,
@@ -63,6 +66,39 @@ final class JwtAccessTokenValidator implements AccessTokenValidator
         private readonly ?string $expectedTokenType = null,
         private readonly ?array $claimCheckers = null,
     ) {
+        if ($this->audience === []) {
+            throw new InvalidArgumentException(
+                '$audience must not be an empty list; use null to disable audience validation.',
+            );
+        }
+
+        if ($this->claimCheckers !== null) {
+            if ($this->audience !== null) {
+                throw new InvalidArgumentException(
+                    '$audience must be null when $claimCheckers is provided; the injected checkers replace it entirely.',
+                );
+            }
+
+            if ($this->claimCheckers === []) {
+                throw new InvalidArgumentException(
+                    '$claimCheckers must not be empty; pass null to use the default claim checkers.',
+                );
+            }
+
+            $seenClaims = [];
+
+            foreach ($this->claimCheckers as $claimChecker) {
+                $claim = $claimChecker->supportedClaim();
+
+                if (isset($seenClaims[$claim])) {
+                    throw new InvalidArgumentException(
+                        sprintf('Duplicate claim checker for claim "%s" in $claimCheckers.', $claim),
+                    );
+                }
+
+                $seenClaims[$claim] = true;
+            }
+        }
     }
 
     /**
@@ -177,14 +213,19 @@ final class JwtAccessTokenValidator implements AccessTokenValidator
      */
     private function createClaimCheckerManager(): ClaimCheckerManager
     {
-        if ($this->claimCheckerManager !== null) {
-            return $this->claimCheckerManager;
-        }
+        return $this->claimCheckerManager ??= new ClaimCheckerManager(
+            $this->claimCheckers ?? $this->defaultClaimCheckers(),
+        );
+    }
 
-        if ($this->claimCheckers !== null) {
-            return $this->claimCheckerManager = new ClaimCheckerManager($this->claimCheckers);
-        }
-
+    /**
+     * @return list<ClaimChecker>
+     *
+     * @throws DiscoveryException if provider metadata cannot be resolved
+     * @throws NetworkException if the discovery endpoint cannot be reached
+     */
+    private function defaultClaimCheckers(): array
+    {
         $checkers = [
             new IssuerChecker([$this->config->issuerMetadata()->issuer()]),
             new ExpirationTimeChecker($this->clock, $this->allowedTimeDrift),
@@ -198,7 +239,7 @@ final class JwtAccessTokenValidator implements AccessTokenValidator
             $checkers[] = $audienceChecker;
         }
 
-        return $this->claimCheckerManager = new ClaimCheckerManager($checkers);
+        return $checkers;
     }
 
     /**

--- a/src/ResourceServer/JwtAccessTokenValidator.php
+++ b/src/ResourceServer/JwtAccessTokenValidator.php
@@ -88,6 +88,7 @@ final class JwtAccessTokenValidator implements AccessTokenValidator
             $seenClaims = [];
 
             foreach ($this->claimCheckers as $claimChecker) {
+                // @phpstan-ignore instanceof.alwaysTrue (runtime guard; PHP arrays don't enforce the docblock's element type)
                 if (!$claimChecker instanceof ClaimChecker) {
                     throw new InvalidArgumentException(
                         sprintf('Each element of $claimCheckers must implement %s.', ClaimChecker::class),

--- a/tests/OidcFactoryTest.php
+++ b/tests/OidcFactoryTest.php
@@ -455,6 +455,55 @@ class OidcFactoryTest extends TestCase
         $this->assertInstanceOf(Oidc::class, $oidc);
     }
 
+    public function testResourceServerAudienceDefaultsToClientId(): void
+    {
+        $oidc = OidcFactory::create(
+            httpClient: $this->jwksHttpClient(),
+            issuer: $this->issuerMetadata,
+            clientId: 'test-client-id',
+        );
+
+        // A token whose audience is not the client id is rejected under the default configuration.
+        $jwt = $this->createSignedJwt(['iss' => 'https://auth.example.com', 'aud' => 'another-client']);
+
+        $this->expectException(InvalidTokenException::class);
+
+        $oidc->resourceServer()->introspect(new JwtAccessToken($jwt));
+    }
+
+    public function testResourceServerAudienceAcceptsConfiguredList(): void
+    {
+        $oidc = OidcFactory::create(
+            httpClient: $this->jwksHttpClient(),
+            issuer: $this->issuerMetadata,
+            clientId: 'test-client-id',
+            resourceServerAudience: ['first-service', 'second-service'],
+        );
+
+        $jwt = $this->createSignedJwt(['iss' => 'https://auth.example.com', 'aud' => 'second-service']);
+
+        $validated = $oidc->resourceServer()->introspect(new JwtAccessToken($jwt));
+
+        $this->assertInstanceOf(ValidatedAccessToken::class, $validated);
+    }
+
+    public function testResourceServerAudienceNullDisablesAudienceCheck(): void
+    {
+        $oidc = OidcFactory::create(
+            httpClient: $this->jwksHttpClient(),
+            issuer: $this->issuerMetadata,
+            clientId: 'test-client-id',
+            resourceServerAudience: null,
+        );
+
+        // Token issued for a different first-party client is accepted because the audience check is off.
+        $jwt = $this->createSignedJwt(['iss' => 'https://auth.example.com', 'aud' => 'some-other-client']);
+
+        $validated = $oidc->resourceServer()->introspect(new JwtAccessToken($jwt));
+
+        $this->assertInstanceOf(ValidatedAccessToken::class, $validated);
+    }
+
     protected function setUp(): void
     {
         parent::setUp();
@@ -499,6 +548,23 @@ class OidcFactoryTest extends TestCase
             ->method('request')
             ->with('GET', $this->anything())
             ->willReturn($response);
+    }
+
+    /**
+     * A mock HTTP client that serves {@see publicJwks()} from the issuer's JWKS endpoint,
+     * so tokens created with {@see createSignedJwt()} verify end-to-end through the factory.
+     */
+    private function jwksHttpClient(): HttpClientInterface&MockObject
+    {
+        $response = $this->createMock(ResponseInterface::class);
+        $response->method('toArray')->willReturn($this->publicJwks());
+
+        $httpClient = $this->createMock(HttpClientInterface::class);
+        $httpClient->method('request')
+            ->with('GET', 'https://auth.example.com/.well-known/jwks.json')
+            ->willReturn($response);
+
+        return $httpClient;
     }
 
     private function setupCacheMock(CacheInterface&MockObject $cache): void

--- a/tests/OidcFactoryTest.php
+++ b/tests/OidcFactoryTest.php
@@ -236,15 +236,8 @@ class OidcFactoryTest extends TestCase
 
     public function testAccessTokenTypeRejectsMismatchWhenConfigured(): void
     {
-        $httpClient = $this->createMock(HttpClientInterface::class);
-        $response = $this->createMock(ResponseInterface::class);
-        $response->method('toArray')->willReturn($this->publicJwks());
-        $httpClient->method('request')
-            ->with('GET', 'https://auth.example.com/.well-known/jwks.json')
-            ->willReturn($response);
-
         $oidc = OidcFactory::create(
-            httpClient: $httpClient,
+            httpClient: $this->jwksHttpClient(),
             issuer: $this->issuerMetadata,
             clientId: 'test-client-id',
             accessTokenType: 'at+jwt',
@@ -263,15 +256,12 @@ class OidcFactoryTest extends TestCase
 
     public function testAccessTokenTypeAllowsAnyTypeByDefault(): void
     {
-        $httpClient = $this->createMock(HttpClientInterface::class);
-        $response = $this->createMock(ResponseInterface::class);
-        $response->method('toArray')->willReturn($this->publicJwks());
-        $httpClient->method('request')
-            ->with('GET', 'https://auth.example.com/.well-known/jwks.json')
-            ->willReturn($response);
-
         // No accessTokenType configured -> the same typ:"JWT" token is accepted.
-        $oidc = OidcFactory::create(httpClient: $httpClient, issuer: $this->issuerMetadata, clientId: 'test-client-id');
+        $oidc = OidcFactory::create(
+            httpClient: $this->jwksHttpClient(),
+            issuer: $this->issuerMetadata,
+            clientId: 'test-client-id',
+        );
 
         $jwt = $this->createSignedJwt(
             ['iss' => 'https://auth.example.com', 'aud' => 'test-client-id'],

--- a/tests/ResourceServer/JwtAccessTokenValidatorTest.php
+++ b/tests/ResourceServer/JwtAccessTokenValidatorTest.php
@@ -10,6 +10,7 @@ use DigitalCz\OpenIDConnect\Discovery\JwksLoader;
 use DigitalCz\OpenIDConnect\Exception\InvalidTokenException;
 use DigitalCz\OpenIDConnect\TestCase;
 use DigitalCz\OpenIDConnect\Util\SimpleClock;
+use InvalidArgumentException;
 use Jose\Component\Checker\IssuerChecker;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -47,6 +48,51 @@ class JwtAccessTokenValidatorTest extends TestCase
         );
 
         $this->assertInstanceOf(JwtAccessTokenValidator::class, $validator);
+    }
+
+    public function testConstructorRejectsEmptyAudienceList(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('$audience must not be an empty list');
+
+        new JwtAccessTokenValidator($this->config, $this->jwksLoader, []);
+    }
+
+    public function testConstructorRejectsClaimCheckersCombinedWithAudience(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('$audience must be null when $claimCheckers is provided');
+
+        new JwtAccessTokenValidator(
+            $this->config,
+            $this->jwksLoader,
+            'test-audience',
+            claimCheckers: [new IssuerChecker(['https://auth.example.com'])],
+        );
+    }
+
+    public function testConstructorRejectsEmptyClaimCheckers(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('$claimCheckers must not be empty');
+
+        new JwtAccessTokenValidator($this->config, $this->jwksLoader, null, claimCheckers: []);
+    }
+
+    public function testConstructorRejectsDuplicateClaimCheckers(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Duplicate claim checker for claim "iss"');
+
+        new JwtAccessTokenValidator(
+            $this->config,
+            $this->jwksLoader,
+            null,
+            claimCheckers: [
+                new IssuerChecker(['https://auth.example.com']),
+                new IssuerChecker(['https://other.example.com']),
+            ],
+        );
     }
 
     public function testSupportsJwtAccessToken(): void
@@ -810,12 +856,12 @@ class JwtAccessTokenValidatorTest extends TestCase
     {
         $this->jwksLoader->method('load')->willReturn($this->publicJwks());
 
-        // Only an issuer check is injected, fully replacing the default set. The configured
-        // $audience is ignored, and neither the audience nor the expiration default checker runs.
+        // Only an issuer check is injected, fully replacing the default set: neither the
+        // audience nor the expiration default checker runs.
         $validator = new JwtAccessTokenValidator(
             $this->config,
             $this->jwksLoader,
-            'ignored-audience',
+            null,
             new SimpleClock(),
             mandatoryClaims: ['iss'],
             claimCheckers: [new IssuerChecker(['https://auth.example.com'])],

--- a/tests/ResourceServer/JwtAccessTokenValidatorTest.php
+++ b/tests/ResourceServer/JwtAccessTokenValidatorTest.php
@@ -10,6 +10,7 @@ use DigitalCz\OpenIDConnect\Discovery\JwksLoader;
 use DigitalCz\OpenIDConnect\Exception\InvalidTokenException;
 use DigitalCz\OpenIDConnect\TestCase;
 use DigitalCz\OpenIDConnect\Util\SimpleClock;
+use Jose\Component\Checker\IssuerChecker;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -699,6 +700,138 @@ class JwtAccessTokenValidatorTest extends TestCase
         $this->expectExceptionMessage('Invalid Access Token:');
 
         $validator->validate(new JwtAccessToken($jwt));
+    }
+
+    public function testValidateAcceptsTokenWhenAudienceIsInConfiguredList(): void
+    {
+        $this->jwksLoader->method('load')->willReturn($this->publicJwks());
+
+        $validator = new JwtAccessTokenValidator(
+            $this->config,
+            $this->jwksLoader,
+            ['first-service', 'second-service'],
+            new SimpleClock(),
+        );
+
+        $jwt = $this->createSignedJwt(['iss' => 'https://auth.example.com', 'aud' => 'second-service']);
+
+        $this->assertInstanceOf(
+            ValidatedAccessToken::class,
+            $validator->validate(new JwtAccessToken($jwt)),
+        );
+    }
+
+    public function testValidateRejectsTokenWhenAudienceNotInConfiguredList(): void
+    {
+        $this->jwksLoader->method('load')->willReturn($this->publicJwks());
+
+        $validator = new JwtAccessTokenValidator(
+            $this->config,
+            $this->jwksLoader,
+            ['first-service', 'second-service'],
+            new SimpleClock(),
+        );
+
+        $jwt = $this->createSignedJwt(['iss' => 'https://auth.example.com', 'aud' => 'third-service']);
+
+        $this->expectException(InvalidTokenException::class);
+        $this->expectExceptionMessage('Invalid Access Token:');
+
+        $validator->validate(new JwtAccessToken($jwt));
+    }
+
+    public function testValidateAcceptsArrayAudienceIntersectingConfiguredList(): void
+    {
+        $this->jwksLoader->method('load')->willReturn($this->publicJwks());
+
+        $validator = new JwtAccessTokenValidator(
+            $this->config,
+            $this->jwksLoader,
+            ['first-service', 'second-service'],
+            new SimpleClock(),
+        );
+
+        // Token carries multiple audiences; one of them is in the configured allow-list.
+        $jwt = $this->createSignedJwt([
+            'iss' => 'https://auth.example.com',
+            'aud' => ['unrelated-service', 'second-service'],
+        ]);
+
+        $this->assertInstanceOf(
+            ValidatedAccessToken::class,
+            $validator->validate(new JwtAccessToken($jwt)),
+        );
+    }
+
+    public function testValidateWithNullAudienceAcceptsForeignAudience(): void
+    {
+        $this->jwksLoader->method('load')->willReturn($this->publicJwks());
+
+        // Audience validation disabled: a token minted for a different first-party client is accepted.
+        $validator = new JwtAccessTokenValidator(
+            $this->config,
+            $this->jwksLoader,
+            null,
+            new SimpleClock(),
+        );
+
+        $jwt = $this->createSignedJwt(['iss' => 'https://auth.example.com', 'aud' => 'some-other-client']);
+
+        $this->assertInstanceOf(
+            ValidatedAccessToken::class,
+            $validator->validate(new JwtAccessToken($jwt)),
+        );
+    }
+
+    public function testValidateWithNullAudienceAcceptsMissingAudienceWhenNotMandatory(): void
+    {
+        $this->jwksLoader->method('load')->willReturn($this->publicJwks());
+
+        // With the audience check disabled and "aud" dropped from the mandatory set, a token
+        // without any "aud" claim is accepted.
+        $validator = new JwtAccessTokenValidator(
+            $this->config,
+            $this->jwksLoader,
+            null,
+            new SimpleClock(),
+            10,
+            ['iss', 'sub', 'exp', 'iat'],
+        );
+
+        $jwt = $this->createSignedJwt(['iss' => 'https://auth.example.com', 'aud' => null]);
+
+        $this->assertInstanceOf(
+            ValidatedAccessToken::class,
+            $validator->validate(new JwtAccessToken($jwt)),
+        );
+    }
+
+    public function testValidateWithInjectedClaimCheckersReplacesDefaultSet(): void
+    {
+        $this->jwksLoader->method('load')->willReturn($this->publicJwks());
+
+        // Only an issuer check is injected, fully replacing the default set. The configured
+        // $audience is ignored, and neither the audience nor the expiration default checker runs.
+        $validator = new JwtAccessTokenValidator(
+            $this->config,
+            $this->jwksLoader,
+            'ignored-audience',
+            new SimpleClock(),
+            mandatoryClaims: ['iss'],
+            claimCheckers: [new IssuerChecker(['https://auth.example.com'])],
+        );
+
+        // Foreign audience AND already expired — both would fail the defaults, both pass here.
+        $jwt = $this->createSignedJwt([
+            'iss' => 'https://auth.example.com',
+            'aud' => 'some-other-client',
+            'exp' => time() - 3600,
+        ]);
+
+        $this->assertInstanceOf(
+            ValidatedAccessToken::class,
+            $validator->validate(new JwtAccessToken($jwt)),
+        );
     }
 
     protected function setUp(): void


### PR DESCRIPTION
Closes #93.

## Problem

`JwtAccessTokenValidator` built its claim checkers in a private method and hardcoded a single-string `AudienceChecker`, with the expected audience tied to `clientId` by `OidcFactory`. The class is `final`, so there was no way to accept multiple audiences, relax audience validation, or replace the checker set short of copying `validate()` verbatim (duplicating signature/JWKS wiring).

## Changes

- **`JwtAccessTokenValidator::$audience`** now accepts `string|list<string>|null`:
  - `string` → unchanged (web-token `AudienceChecker`).
  - `list<string>` → accepts a token whose `aud` (string or array) matches **any** configured value, via web-token's standard `CallableChecker` (no custom class). This is the standard model for a resource server with multiple identities (RFC 9068 §4).
  - `null` → disables the audience check. Presence of `aud` is still governed by `$mandatoryClaims`.
- **`$claimCheckers` escape hatch** — when provided, fully replaces the default checker set (issuer/audience/expiry/issued-at/not-before) for custom validation.
- **`OidcFactory::create()`** gains **`$resourceServerAudience`** (`false` = default to `clientId`, `string|list` = custom, `null` = disable), decoupling the expected audience from `clientId`. The `false` sentinel preserves full backward compatibility.
- **Docs** — README documents the options and flags that disabling the audience check is a **deliberate deviation from RFC 9068** (standards-correct alternative: Token Exchange, RFC 8693). Example updated.

## Backward compatibility

Fully preserved: unset `resourceServerAudience` keeps `aud` == `clientId`; a plain-`string` `$audience` behaves exactly as before.

## Tests

Added to `JwtAccessTokenValidatorTest` (list match/mismatch, array-aud intersection, `null` accepts foreign audience, `null` accepts missing `aud` when not mandatory, injected `claimCheckers` replaces defaults) and `OidcFactoryTest` (default requires `clientId`, list, `null` disables — end-to-end through the factory with signed tokens).

`composer checks` (phpcs, phpstan, phpunit — 609 tests) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F7mS2RfBZNi6KEoPFfgXU4